### PR TITLE
Simplify pip dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing Guide
+
+## Build documentation locally
+
+Installs dependencies for building the docs:
+
+```shell
+pip install -r requirements.txt
+```
+
+Serve docs locally:
+
+```shell
+./download_lce_readme.sh
+python generate_api_docs.py
+mkdocs serve
+```
+
+## Build documentation locally using `npm`
+
+Installs dependencies for building the docs:
+
+```shell
+npm install
+```
+
+Serve docs locally:
+
+```shell
+npm run prebuild
+npm run dev
+```

--- a/package.json
+++ b/package.json
@@ -2,8 +2,7 @@
   "name": "docs.larq.dev",
   "private": true,
   "scripts": {
-    "preinstall": "python3 -m pip install nbconvert",
-    "install": "python3 -m pip install git+https://github.com/lgeiger/pydoc-markdown.git -r requirements.txt",
+    "install": "python3 -m pip install -r requirements.txt",
     "prebuild": "./download_lce_readme.sh && python3 generate_api_docs.py",
     "build:docs": "python3 -m mkdocs build -d public",
     "build": "npm run build:docs && npm run build:docs",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ mkdocs-minify-plugin==0.2.3
 larq-zoo==0.5.0
 altair==4.0.1
 pandas==1.0.1
+git+https://github.com/lgeiger/pydoc-markdown.git


### PR DESCRIPTION
`mknotebooks` fixed their dependency on `nbconvert` so we don't need to install it before.