### PR TITLE
Add pydoc-markdown==2.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ mkdocs-minify-plugin==0.2.3
 larq-zoo==0.5.0
 altair==4.0.1
 pandas==1.0.1
+pydoc-markdown==2.0.5


### PR DESCRIPTION
Following build instructions in CONTRIBUTING.md in a clean Python 3 virtual environment failed with a module not found error for `pydocmd`; this fixes that.