### PR TITLE
Deduplicate navigation

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -76,13 +76,14 @@ button[data-md-color-accent="larq"] {
     background-color: #0a1d3c;
   }
 }
-@media only screen and (min-width: 76.25em) {
-  [data-md-color-primary="larq"] .md-tabs {
-    background-color: #0a1d3c;
-  }
-  [data-md-color-primary=white] .md-tabs {
-    border: none;
-  }
+[data-md-color-primary="larq"] .md-tabs {
+  background-color: #0a1d3c;
+}
+[data-md-color-primary="white"] .md-tabs {
+  border: none;
+  display: block;
+  background-color: #fff;
+  color: rgba(0, 0, 0, 0.87);
 }
 .md-typeset table:not([class]) th {
   background-color: #0a1d3c;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ nav:
           - Math: larq/api/math.md
           - Models: larq/api/models.md
           - Metrics: larq/api/metrics.md
+      - FAQ: faq.md
   - Zoo:
       - Getting Started: zoo/index.md
       - Tutorials: zoo/tutorials.ipynb
@@ -41,7 +42,6 @@ nav:
           - Build from source: compute-engine/build.md
           - Build for ARM: compute-engine/build_arm.md
       - API: compute-engine/api/index.md
-  - FAQ: faq.md
 
 repo_url: https://github.com/larq/larq
 repo_name: larq/larq
@@ -57,6 +57,8 @@ theme:
   font:
     text: "Work Sans"
     code: "Roboto Mono"
+  feature:
+    tabs: true
 
 extra:
   social:

--- a/theme/partials/tabs.html
+++ b/theme/partials/tabs.html
@@ -1,0 +1,2 @@
+<!-- Noop component to simplify sidebar appearence -->
+<nav class="md-tabs md-tabs--active"></nav>


### PR DESCRIPTION
This deduplicates the site navigation so that the tab bar is not repeated on the left sidebar.

I don't have strong feelings about this, but I think I prefer this design since it make it easier to navigate on the docs.

Here is a preview of this design: https://docs-4lbqsgt83.now.sh/