### PR TITLE
Correct model accuracies

### DIFF
--- a/docs/zoo/index.md
+++ b/docs/zoo/index.md
@@ -40,9 +40,9 @@ The [`sota`](/zoo/api/sota/) submodule contains these models:
 
 | Model                                         | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
 | --------------------------------------------- | -------------- | -------------- | ---------- | ------- |
-| [QuickNet](/zoo/api/sota/#quicknet)           | 58.7 %         | 81.0 %         | 10 518 528 | 3.21 MB |
-| [QuickNetLarge](/zoo/api/sota/#quicknetlarge) | 62.8 %         | 84.0 %         | 11 837 696 | 4.56 MB |
-| [QuickNetXL](/zoo/api/sota/#quicknetxl)       | 67.1 %         | 87.3 %         | 22 058 368 | 6.22 MB |
+| [QuickNet](/zoo/api/sota/#quicknet)           | 58.6 %         | 81.0 %         | 10 518 528 | 3.21 MB |
+| [QuickNetLarge](/zoo/api/sota/#quicknetlarge) | 62.7 %         | 84.0 %         | 11 837 696 | 4.56 MB |
+| [QuickNetXL](/zoo/api/sota/#quicknetxl)       | 67.0 %         | 87.3 %         | 22 058 368 | 6.22 MB |
 
 ## Installation
 


### PR DESCRIPTION
It looks like the accuracies quoted here were taken from TensorBoard which might not be 100% accurate since the eval dataset is repeated during training so the last batch of the epoch can include duplicated samples. This PR corrects this by quoting the accuracies from `model.evaluate` with the models downloaded from larq zoo.