### PR TITLE
Add model summary renderer

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -24,14 +24,15 @@
   color: inherit;
 }
 
-.output pre {
+.output pre,
+.model-summary {
   overflow: scroll;
   max-height: 20rem;
 }
 
 .notebook-badge {
-  border: .05rem solid var(--md-default-fg-color--lightest);
-  padding: .45em 1.05em;
+  border: 0.05rem solid var(--md-default-fg-color--lightest);
+  padding: 0.45em 1.05em;
   border-radius: 2px;
   cursor: pointer;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -86,6 +86,9 @@ markdown_extensions:
         - name: netron
           class: larq-netron
           format: !!python/name:netron_link.html_format
+        - name: summary
+          class: larq-netron
+          format: !!python/name:model_summary.html_format
   - pymdownx.arithmatex
   - toc:
       permalink: true

--- a/model_summary.py
+++ b/model_summary.py
@@ -1,0 +1,16 @@
+import larq_zoo as lqz
+import larq as lq
+import io
+from functools import reduce
+
+
+def html_format(source, language, css_class, options, md):
+    model_fn = reduce(getattr, [lqz, *source.split(".")])
+    stream = io.StringIO()
+    lq.models.summary(model_fn(weights=None), print_fn=lambda s: print(s, file=stream))
+    return f"""
+    <details class="abstract"
+      ><summary>Model Summary</summary>
+      <pre class="model-summary"><code>{stream.getvalue()}</code></pre>
+    </details>
+    """

--- a/model_summary.py
+++ b/model_summary.py
@@ -1,3 +1,4 @@
+import tensorflow as tf
 import larq_zoo as lqz
 import larq as lq
 import io
@@ -7,6 +8,7 @@ from functools import reduce
 def html_format(source, language, css_class, options, md):
     model_fn = reduce(getattr, [lqz, *source.split(".")])
     stream = io.StringIO()
+    tf.keras.backend.clear_session()
     lq.models.summary(model_fn(weights=None), print_fn=lambda s: print(s, file=stream))
     return f"""
     <details class="abstract"


### PR DESCRIPTION
This adds a renderer that will display a collapsible model summary if a docstring adds the following block:

```
'''summary
sota.QuickNet
'''
```

![Screenshot 2020-04-16 at 16 33 27](https://user-images.githubusercontent.com/13285808/79487573-5d37ee00-8010-11ea-8fcd-16ace1a2da50.png)
