### PR TITLE
Improve styling of netron link to make it consistent with model summary

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -44,3 +44,9 @@
   opacity: 1;
   visibility: visible;
 }
+
+.md-typeset a.netron-link {
+  color: var(--md-default-fg-color);
+  font-weight: 700;
+  line-height: 1em;
+}

--- a/netron_link.py
+++ b/netron_link.py
@@ -4,4 +4,4 @@ release_url = "https://github.com/larq/zoo/releases/download"
 
 
 def html_format(source, language, css_class, options, md):
-    return f'<a href="{netron_link}/?url={cors_proxy}/{release_url}/{source}">Interactive architecture diagram</a>'
+    return f'<div class="admonition abstract"><a class="netron-link" href="{netron_link}/?url={cors_proxy}/{release_url}/{source}"><p>Interactive architecture diagram</p></a></div>'


### PR DESCRIPTION
This modifies the styling of the netron link to make the appearance consistent with the model summary:
<img width="717" alt="Screenshot 2020-04-16 at 19 29 46" src="https://user-images.githubusercontent.com/13285808/79493364-48ac2380-8019-11ea-907b-7d9bb1dca0d5.png">
