### PR TITLE
Move LCE readme into docs repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-docs/compute-engine/index.md
 docs/plots/generated
 docs/*/api
 package-lock.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ pip install -r requirements.txt
 Serve docs locally:
 
 ```shell
-./download_lce_readme.sh
 python generate_api_docs.py
 python -m mkdocs serve
 ```

--- a/docs/compute-engine/index.md
+++ b/docs/compute-engine/index.md
@@ -61,7 +61,7 @@ and a Raspberry Pi 4 Model B ([BCM2711](https://www.raspberrypi.org/documentatio
     | [QuickNet-Large](/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) |     62.7 %     |    31.8      |     16.9     |
     | [QuickNet-XL](/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))             |     67.0 %     |    52.4      |     29.7     |
 
-For reference, [dabnn](https://github.com/JDAI-CV/dabnn) (the other main BNN library) reports an inference time of 61.3 ms for [Bi-RealNet](/larq/api/larq_zoo/#birealnet) (56.4% accuracy) on the Pixel 1 phone,
+For reference, [dabnn](https://github.com/JDAI-CV/dabnn) (the other main BNN library) reports an inference time of 61.3 ms for [Bi-RealNet](/zoo/api/literature/#birealnet) (56.4% accuracy) on the Pixel 1 phone,
 while LCE achieves an inference time of 47.7 ms for Bi-RealNet on the same device.
 They furthermore present a modified version, BiRealNet-Stem, which achieves the same accuracy of 56.4% in 43.2 ms.
 
@@ -87,7 +87,7 @@ Follow these steps to deploy a BNN with LCE:
 
 ## Next steps
 
-- Explore [Larq pre-trained models](/larq/api/larq_zoo).
+- Explore [Larq pre-trained models](/zoo/).
 - Learn how to [build](/larq/guides/bnn-architecture/) and
   [train](/larq/guides/bnn-optimization/) BNNs for your own
   application with Larq.

--- a/docs/compute-engine/index.md
+++ b/docs/compute-engine/index.md
@@ -21,10 +21,10 @@ advantage of multi-core modern desktop and mobile CPUs.
       TensorFlow provides a smooth end-to-end training and deployment experience.
 
     - A collection of Larq pre-trained BNN models for common machine learning tasks
-      is available in [Larq Zoo](https://docs.larq.dev/zoo/)
+      is available in [Larq Zoo](/zoo/)
       and can be used out-of-the-box with LCE.
 
-    - LCE provides a custom [MLIR-based model converter](https://docs.larq.dev/compute-engine/converter) which
+    - LCE provides a custom [MLIR-based model converter](/compute-engine/converter/) which
       is fully compatible with TensorFlow Lite and performs additional
       network level optimizations for Larq models.
 
@@ -42,17 +42,17 @@ advantage of multi-core modern desktop and mobile CPUs.
 ## Performance
 
 The table below presents **single-threaded** performance of Larq Compute Engine on
-different versions of a novel BNN model called QuickNet (trained on ImageNet dataset, soon to be released in [Larq Zoo](https://docs.larq.dev/zoo/))
+different versions of a novel BNN model called QuickNet (trained on ImageNet dataset, soon to be released in [Larq Zoo](/zoo/))
 on a [Pixel 1 phone (2016)](https://support.google.com/pixelphone/answer/7158570?hl=en-GB)
 and a Raspberry Pi 4 Model B ([BCM2711](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/README.md)) board:
 
-| Model                                                                                                                 | Top-1 Accuracy | RPi 4 B, ms (1 thread) | Pixel 1, ms (1 thread) |
-| ------------------------------------------------------------------------------------------------                      | :------------: | :--------------------: | :--------------------: |
-| [QuickNet](https://docs.larq.dev/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v0.2.0/quicknet_weights.h5))                   | 58.6 %         | 45.6                   | 21.2                   |
-| [QuickNet-Large](https://docs.larq.dev/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) | 62.7 %         | 66.5                   | 32.0                   |
-| [QuickNet-XL](https://docs.larq.dev/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))                                                                                         | 67.0 %         | 121.2                  | 55.8                   |
+| Model                                                                                                                                                 | Top-1 Accuracy | RPi 4 B, ms (1 thread) | Pixel 1, ms (1 thread) |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :--------------------: | :--------------------: |
+| [QuickNet](/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v0.2.0/quicknet_weights.h5))                        |     58.6 %     |          45.6          |          21.2          |
+| [QuickNet-Large](/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) |     62.7 %     |          66.5          |          32.0          |
+| [QuickNet-XL](/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))             |     67.0 %     |         121.2          |          55.8          |
 
-For reference, [dabnn](https://github.com/JDAI-CV/dabnn) (the other main BNN library) reports an inference time of 61.3 ms for [Bi-RealNet](https://docs.larq.dev/larq/api/larq_zoo/#birealnet) (56.4% accuracy) on the Pixel 1 phone,
+For reference, [dabnn](https://github.com/JDAI-CV/dabnn) (the other main BNN library) reports an inference time of 61.3 ms for [Bi-RealNet](/larq/api/larq_zoo/#birealnet) (56.4% accuracy) on the Pixel 1 phone,
 while LCE achieves an inference time of 47.7 ms for Bi-RealNet on the same device.
 They furthermore present a modified version, BiRealNet-Stem, which achieves the same accuracy of 56.4% in 43.2 ms.
 
@@ -60,11 +60,11 @@ The following table presents **multi-threaded** performance of Larq Compute Engi
 a Pixel 1 phone and a Raspberry Pi 4 Model B ([BCM2711](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/README.md))
 board:
 
-| Model                                                                                                                 | Top-1 Accuracy | RPi 4 B, ms (4 threads) | Pixel 1, ms (4 threads) |
-| ------------------------------------------------------------------------------------------------                      | :------------: | :---------------------: | :---------------------: |
-| [QuickNet](https://docs.larq.dev/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v0.2.0/quicknet_weights.h5))                   | 58.6 %         | 21.7                    | 11.6                    |
-| [QuickNet-Large](https://docs.larq.dev/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) | 62.7 %         | 31.8                    | 16.9                    |
-| [QuickNet-XL](https://docs.larq.dev/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))                                                                                         | 67.0 %         | 52.4                    | 29.7                    |
+| Model                                                                                                                                                 | Top-1 Accuracy | RPi 4 B, ms (4 threads) | Pixel 1, ms (4 threads) |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :---------------------: | :---------------------: |
+| [QuickNet](/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v0.2.0/quicknet_weights.h5))                        |     58.6 %     |          21.7           |          11.6           |
+| [QuickNet-Large](/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) |     62.7 %     |          31.8           |          16.9           |
+| [QuickNet-XL](/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))             |     67.0 %     |          52.4           |          29.7           |                                                 | 67.0 %         | 52.4                    | 29.7                    |
 
 
 Benchmarked on March 20th, 2020 with LCE custom
@@ -78,26 +78,26 @@ Follow these steps to deploy a BNN with LCE:
 
 1. **Pick a Larq model**
 
-    You can use [Larq](https://larq.dev) to build and train your own model or pick a pre-trained model from [Larq Zoo](https://docs.larq.dev/zoo/).
+    You can use [Larq](https://larq.dev) to build and train your own model or pick a pre-trained model from [Larq Zoo](/zoo/).
 
 2. **Convert the Larq model**
 
-    LCE is built on top of TensorFlow Lite and uses the TensorFlow Lite [FlatBuffer format](https://google.github.io/flatbuffers/) to convert and serialize Larq models for inference. We provide an [LCE Converter](https://docs.larq.dev/compute-engine/converter) with additional optimization passes to increase the speed of execution of Larq models on supported target platforms.
+    LCE is built on top of TensorFlow Lite and uses the TensorFlow Lite [FlatBuffer format](https://google.github.io/flatbuffers/) to convert and serialize Larq models for inference. We provide an [LCE Converter](/compute-engine/converter/) with additional optimization passes to increase the speed of execution of Larq models on supported target platforms.
 
 3. **Build LCE**
 
-    The LCE documentation provides the build instructions for [Android](https://docs.larq.dev/compute-engine/quickstart_android) and [ARM64-based boards](https://docs.larq.dev/compute-engine/build_arm) such as Raspberry Pi. Please follow the provided instructions to create a native LCE build or cross-compile for one of the supported targets.
+    The LCE documentation provides the build instructions for [Android](/compute-engine/quickstart_android) and [ARM64-based boards](/compute-engine/build_arm) such as Raspberry Pi. Please follow the provided instructions to create a native LCE build or cross-compile for one of the supported targets.
 
 4. **Run inference**
 
-    LCE uses the [TensorFlow Lite Interpreter](https://www.tensorflow.org/lite/guide/inference) to perform an inference. In addition to the already available built-in TensorFlow Lite operators, optimized LCE operators are registered to the interpreter to execute the Larq specific subgraphs of the model. An example to create and build an LCE compatible TensorFlow Lite interpreter for your own applications is provided [here](https://docs.larq.dev/compute-engine/inference).
+    LCE uses the [TensorFlow Lite Interpreter](https://www.tensorflow.org/lite/guide/inference) to perform an inference. In addition to the already available built-in TensorFlow Lite operators, optimized LCE operators are registered to the interpreter to execute the Larq specific subgraphs of the model. An example to create and build an LCE compatible TensorFlow Lite interpreter for your own applications is provided [here](/compute-engine/inference).
 
 ## Next steps
 
-- Explore [Larq pre-trained models](https://docs.larq.dev/larq/api/larq_zoo).
-- Learn how to [build](https://docs.larq.dev/larq/guides/bnn-architecture/) and
-  [train](https://docs.larq.dev/larq/guides/bnn-optimization/) BNNs for your own
+- Explore [Larq pre-trained models](/larq/api/larq_zoo).
+- Learn how to [build](/larq/guides/bnn-architecture/) and
+  [train](/larq/guides/bnn-optimization/) BNNs for your own
   application with Larq.
-- If you're a mobile developer, visit [Android quickstart](https://docs.larq.dev/compute-engine/quickstart_android).
-- See our build instructions for Raspberry Pi and Arm64-based boards [here](https://docs.larq.dev/compute-engine/build_arm).
+- If you're a mobile developer, visit [Android quickstart](/compute-engine/quickstart_android).
+- See our build instructions for Raspberry Pi and Arm64-based boards [here](/compute-engine/build_arm).
 - Try our [example programs](https://github.com/larq/compute-engine/tree/master/examples).

--- a/docs/compute-engine/index.md
+++ b/docs/compute-engine/index.md
@@ -64,7 +64,7 @@ board:
 | ----------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :---------------------: | :---------------------: |
 | [QuickNet](/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v0.2.0/quicknet_weights.h5))                        |     58.6 %     |          21.7           |          11.6           |
 | [QuickNet-Large](/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) |     62.7 %     |          31.8           |          16.9           |
-| [QuickNet-XL](/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))             |     67.0 %     |          52.4           |          29.7           |                                                 | 67.0 %         | 52.4                    | 29.7                    |
+| [QuickNet-XL](/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))             |     67.0 %     |          52.4           |          29.7           |
 
 
 Benchmarked on March 20th, 2020 with LCE custom

--- a/docs/compute-engine/index.md
+++ b/docs/compute-engine/index.md
@@ -1,0 +1,103 @@
+# Larq Compute Engine
+
+Larq Compute Engine (LCE) is a highly optimized inference engine for deploying
+extremely quantized neural networks, such as
+Binarized Neural Networks (BNNs). It currently supports various mobile platforms
+and has been benchmarked on a Pixel 1 phone and a Raspberry Pi.
+LCE provides a collection of hand-optimized [TensorFlow Lite](https://www.tensorflow.org/lite)
+custom operators for supported instruction sets, developed in inline assembly or in C++
+using compiler intrinsics. LCE leverages optimization techniques
+such as **tiling** to maximize the number of cache hits, **vectorization** to maximize
+the computational throughput, and **multi-threading parallelization** to take
+advantage of multi-core modern desktop and mobile CPUs.
+
+*Larq Compute Engine is part of a family of libraries for BNN development; you can also check out [Larq](https://github.com/larq/larq) for building and training BNNs and [Larq Zoo](https://github.com/larq/zoo) for pre-trained models.*
+
+## Key Features
+
+- **Effortless end-to-end integration** from training to deployment:
+
+    - Tight integration of LCE with [Larq](https://larq.dev) and
+      TensorFlow provides a smooth end-to-end training and deployment experience.
+
+    - A collection of Larq pre-trained BNN models for common machine learning tasks
+      is available in [Larq Zoo](https://docs.larq.dev/zoo/)
+      and can be used out-of-the-box with LCE.
+
+    - LCE provides a custom [MLIR-based model converter](https://docs.larq.dev/compute-engine/converter) which
+      is fully compatible with TensorFlow Lite and performs additional
+      network level optimizations for Larq models.
+
+- **Lightning fast deployment** on a variety of mobile platforms:
+
+    - LCE enables high performance, on-device machine learning inference by
+      providing hand-optimized kernels and network level optimizations for BNN models.
+
+    - LCE currently supports ARM64-based mobile platforms such as Android phones
+      and Raspberry Pi boards.
+
+    - Thread parallelism support in LCE is essential for modern mobile devices with
+      multi-core CPUs.
+
+## Performance
+
+The table below presents **single-threaded** performance of Larq Compute Engine on
+different versions of a novel BNN model called QuickNet (trained on ImageNet dataset, soon to be released in [Larq Zoo](https://docs.larq.dev/zoo/))
+on a [Pixel 1 phone (2016)](https://support.google.com/pixelphone/answer/7158570?hl=en-GB)
+and a Raspberry Pi 4 Model B ([BCM2711](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/README.md)) board:
+
+| Model                                                                                                                 | Top-1 Accuracy | RPi 4 B, ms (1 thread) | Pixel 1, ms (1 thread) |
+| ------------------------------------------------------------------------------------------------                      | :------------: | :--------------------: | :--------------------: |
+| [QuickNet](https://docs.larq.dev/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v0.2.0/quicknet_weights.h5))                   | 58.6 %         | 45.6                   | 21.2                   |
+| [QuickNet-Large](https://docs.larq.dev/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) | 62.7 %         | 66.5                   | 32.0                   |
+| [QuickNet-XL](https://docs.larq.dev/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))                                                                                         | 67.0 %         | 121.2                  | 55.8                   |
+
+For reference, [dabnn](https://github.com/JDAI-CV/dabnn) (the other main BNN library) reports an inference time of 61.3 ms for [Bi-RealNet](https://docs.larq.dev/larq/api/larq_zoo/#birealnet) (56.4% accuracy) on the Pixel 1 phone,
+while LCE achieves an inference time of 47.7 ms for Bi-RealNet on the same device.
+They furthermore present a modified version, BiRealNet-Stem, which achieves the same accuracy of 56.4% in 43.2 ms.
+
+The following table presents **multi-threaded** performance of Larq Compute Engine on
+a Pixel 1 phone and a Raspberry Pi 4 Model B ([BCM2711](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/README.md))
+board:
+
+| Model                                                                                                                 | Top-1 Accuracy | RPi 4 B, ms (4 threads) | Pixel 1, ms (4 threads) |
+| ------------------------------------------------------------------------------------------------                      | :------------: | :---------------------: | :---------------------: |
+| [QuickNet](https://docs.larq.dev/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v0.2.0/quicknet_weights.h5))                   | 58.6 %         | 21.7                    | 11.6                    |
+| [QuickNet-Large](https://docs.larq.dev/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) | 62.7 %         | 31.8                    | 16.9                    |
+| [QuickNet-XL](https://docs.larq.dev/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))                                                                                         | 67.0 %         | 52.4                    | 29.7                    |
+
+
+Benchmarked on March 20th, 2020 with LCE custom
+[TFLite Model Benchmark Tool](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/benchmark)
+(see [here](https://github.com/larq/compute-engine/tree/master/larq_compute_engine/tflite/benchmark))
+and BNN models with randomized weights and inputs.
+
+## Getting started
+
+Follow these steps to deploy a BNN with LCE:
+
+1. **Pick a Larq model**
+
+    You can use [Larq](https://larq.dev) to build and train your own model or pick a pre-trained model from [Larq Zoo](https://docs.larq.dev/zoo/).
+
+2. **Convert the Larq model**
+
+    LCE is built on top of TensorFlow Lite and uses the TensorFlow Lite [FlatBuffer format](https://google.github.io/flatbuffers/) to convert and serialize Larq models for inference. We provide an [LCE Converter](https://docs.larq.dev/compute-engine/converter) with additional optimization passes to increase the speed of execution of Larq models on supported target platforms.
+
+3. **Build LCE**
+
+    The LCE documentation provides the build instructions for [Android](https://docs.larq.dev/compute-engine/quickstart_android) and [ARM64-based boards](https://docs.larq.dev/compute-engine/build_arm) such as Raspberry Pi. Please follow the provided instructions to create a native LCE build or cross-compile for one of the supported targets.
+
+4. **Run inference**
+
+    LCE uses the [TensorFlow Lite Interpreter](https://www.tensorflow.org/lite/guide/inference) to perform an inference. In addition to the already available built-in TensorFlow Lite operators, optimized LCE operators are registered to the interpreter to execute the Larq specific subgraphs of the model. An example to create and build an LCE compatible TensorFlow Lite interpreter for your own applications is provided [here](https://docs.larq.dev/compute-engine/inference).
+
+## Next steps
+
+- Explore [Larq pre-trained models](https://docs.larq.dev/larq/api/larq_zoo).
+- Learn how to [build](https://docs.larq.dev/larq/guides/bnn-architecture/) and
+  [train](https://docs.larq.dev/larq/guides/bnn-optimization/) BNNs for your own
+  application with Larq.
+- If you're a mobile developer, visit [Android quickstart](https://docs.larq.dev/compute-engine/quickstart_android).
+- See our build instructions for Raspberry Pi and Arm64-based boards [here](https://docs.larq.dev/compute-engine/build_arm).
+- Try our [example programs](https://github.com/larq/compute-engine/tree/master/examples).

--- a/docs/compute-engine/index.md
+++ b/docs/compute-engine/index.md
@@ -41,36 +41,29 @@ advantage of multi-core modern desktop and mobile CPUs.
 
 ## Performance
 
-The table below presents **single-threaded** performance of Larq Compute Engine on
-different versions of a novel BNN model called QuickNet (trained on ImageNet dataset, soon to be released in [Larq Zoo](/zoo/))
-on a [Pixel 1 phone (2016)](https://support.google.com/pixelphone/answer/7158570?hl=en-GB)
+The table below presents single and multi-threaded performance of Larq Compute Engine[^1] on
+different versions of a novel BNN model called QuickNet on a [Pixel 1 phone (2016)](https://support.google.com/pixelphone/answer/7158570?hl=en-GB)
 and a Raspberry Pi 4 Model B ([BCM2711](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/README.md)) board:
 
-| Model                                                                                                                                                 | Top-1 Accuracy | RPi 4 B, ms (1 thread) | Pixel 1, ms (1 thread) |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :--------------------: | :--------------------: |
-| [QuickNet](/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v0.2.0/quicknet_weights.h5))                        |     58.6 %     |          45.6          |          21.2          |
-| [QuickNet-Large](/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) |     62.7 %     |          66.5          |          32.0          |
-| [QuickNet-XL](/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))             |     67.0 %     |         121.2          |          55.8          |
+=== "Single Thread"
+
+    | Model                                                                                                                                                 | Top-1 Accuracy | Raspberry Pi 4 (ms) | Pixel 1 (ms) |
+    | ----------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :----------: | :----------: |
+    | [QuickNet](/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v0.2.0/quicknet_weights.h5))                        |     58.6 %     |    45.6      |     21.2     |
+    | [QuickNet-Large](/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) |     62.7 %     |    66.5      |     32.0     |
+    | [QuickNet-XL](/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))             |     67.0 %     |    121.2     |     55.8     |
+
+=== "4 Threads"
+
+    | Model                                                                                                                                                 | Top-1 Accuracy | Raspberry Pi 4 (ms) | Pixel 1 (ms) |
+    | ----------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :----------: | :----------: |
+    | [QuickNet](/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v0.2.0/quicknet_weights.h5))                        |     58.6 %     |    21.7      |     11.6     |
+    | [QuickNet-Large](/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) |     62.7 %     |    31.8      |     16.9     |
+    | [QuickNet-XL](/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))             |     67.0 %     |    52.4      |     29.7     |
 
 For reference, [dabnn](https://github.com/JDAI-CV/dabnn) (the other main BNN library) reports an inference time of 61.3 ms for [Bi-RealNet](/larq/api/larq_zoo/#birealnet) (56.4% accuracy) on the Pixel 1 phone,
 while LCE achieves an inference time of 47.7 ms for Bi-RealNet on the same device.
 They furthermore present a modified version, BiRealNet-Stem, which achieves the same accuracy of 56.4% in 43.2 ms.
-
-The following table presents **multi-threaded** performance of Larq Compute Engine on
-a Pixel 1 phone and a Raspberry Pi 4 Model B ([BCM2711](https://www.raspberrypi.org/documentation/hardware/raspberrypi/bcm2711/README.md))
-board:
-
-| Model                                                                                                                                                 | Top-1 Accuracy | RPi 4 B, ms (4 threads) | Pixel 1, ms (4 threads) |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------- | :------------: | :---------------------: | :---------------------: |
-| [QuickNet](/zoo/api/sota/#quicknet) ([.h5](https://github.com/larq/zoo/releases/download/quicknet-v0.2.0/quicknet_weights.h5))                        |     58.6 %     |          21.7           |          11.6           |
-| [QuickNet-Large](/zoo/api/sota/#quicknetlarge) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_large-v0.2.0/quicknet_large_weights.h5)) |     62.7 %     |          31.8           |          16.9           |
-| [QuickNet-XL](/zoo/api/sota/#quicknetxl) ([.h5](https://github.com/larq/zoo/releases/download/quicknet_xl-v0.1.0/quicknet_xl_weights.h5))             |     67.0 %     |          52.4           |          29.7           |
-
-
-Benchmarked on March 20th, 2020 with LCE custom
-[TFLite Model Benchmark Tool](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/benchmark)
-(see [here](https://github.com/larq/compute-engine/tree/master/larq_compute_engine/tflite/benchmark))
-and BNN models with randomized weights and inputs.
 
 ## Getting started
 
@@ -101,3 +94,7 @@ Follow these steps to deploy a BNN with LCE:
 - If you're a mobile developer, visit [Android quickstart](/compute-engine/quickstart_android).
 - See our build instructions for Raspberry Pi and Arm64-based boards [here](/compute-engine/build_arm).
 - Try our [example programs](https://github.com/larq/compute-engine/tree/master/examples).
+
+
+[^1]: Benchmarked on March 20th, 2020 with LCE custom
+[TFLite Model Benchmark Tool](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/tools/benchmark) (see [here](https://github.com/larq/compute-engine/tree/master/larq_compute_engine/tflite/benchmark)) and BNN models with randomized inputs.

--- a/download_lce_readme.sh
+++ b/download_lce_readme.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -e
-basedir=`dirname $0`
-
-# Fetch compute-engine README
-echo "# Larq Compute Engine" > $basedir/docs/compute-engine/index.md
-curl https://raw.githubusercontent.com/larq/compute-engine/master/README.md | tail -n +4 >> $basedir/docs/compute-engine/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ markdown_extensions:
           class: larq-netron
           format: !!python/name:netron_link.html_format
   - pymdownx.arithmatex
+  - pymdownx.tabbed
   - toc:
       permalink: true
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "install": "python3 -m pip install -r requirements.txt",
-    "prebuild": "./download_lce_readme.sh && python3 generate_api_docs.py",
+    "prebuild": "python3 generate_api_docs.py",
     "build:docs": "python3 -m mkdocs build -d public",
     "build": "npm run build:docs && npm run build:docs",
     "dev": "python3 -m mkdocs serve"


### PR DESCRIPTION
Previously we rendered the landing page of Larq Compute Engine directly from the GitHub repo. 
This PR moves the markdown for the index page into this repo which allows us to take advantage of tabs and footnotes. This makes it possible to simplify the benchmark results which should hopefully make them easier to comprehend at a glance.

The rendered version looks like this: https://docs-233908tq2.now.sh/compute-engine/#performance