### PR TITLE
Hardcode Quantizer API docs to remove duplicates

### DIFF
--- a/apidocs.yml
+++ b/apidocs.yml
@@ -18,7 +18,15 @@
 - larq/api/metrics.md:
     - larq.metrics+
 - larq/api/quantizers.md:
-    - larq.quantizers+
+    - larq.quantizers:
+        - larq.quantizers.SteSign
+        - larq.quantizers.ApproxSign
+        - larq.quantizers.SteHeaviside
+        - larq.quantizers.SwishSign
+        - larq.quantizers.MagnitudeAwareSign
+        - larq.quantizers.SteTern
+        - larq.quantizers.DoReFa
+        - larq.quantizers.NoOp
 - zoo/api/index.md:
     - larq_zoo:
         - larq_zoo.decode_predictions


### PR DESCRIPTION
The rename in https://github.com/larq/larq/pull/468 resulted in some quantizers to show up twice in the API docs. This PR hardcodes the names for now to fix it.