### PR TITLE
Always ensure trailing slashes in URLs 

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,4 +1,5 @@
 {
   "version": 2,
-  "github": { "silent": true }
+  "github": { "silent": true },
+  "trailingSlash": true
 }


### PR DESCRIPTION
This will ensure that ~~Zeit~~Vercel will always add a trailing slash to the URL which prevents issues that happend previously when navigating on a page that didn't have a trailing slash. E.g. navigation on sites like https://docs.larq.dev/compute-engine would be broken before where as https://docs.larq.dev/compute-engine/ worked as expected.

See https://vercel.com/docs/configuration#project/trailingslash