### PR TITLE
Improve notebook CSS

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -51,3 +51,25 @@
   font-weight: 700;
   line-height: 1em;
 }
+
+.input code {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.input pre {
+  margin-bottom: 0;
+}
+
+.output code {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  background-color: unset;
+  border: 1px solid var(--md-code-bg-color);
+  border-top: none;
+}
+
+.output pre {
+  margin-top: 0;
+  display: grid;
+}

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -24,7 +24,6 @@
   color: inherit;
 }
 
-.output pre,
 .model-summary {
   overflow: scroll;
   max-height: 20rem;
@@ -67,6 +66,7 @@
   background-color: unset;
   border: 1px solid var(--md-code-bg-color);
   border-top: none;
+  max-height: 20rem;
 }
 
 .output pre {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,3 +110,5 @@ plugins:
       minify_html: true
   - mknotebooks:
       execute: false
+      enable_default_jupyter_cell_styling: false
+      enable_default_pandas_dataframe_styling: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ larq==0.9.4
 mkdocs==1.1
 mkdocs-material==5.1.4
 pymdown-extensions==7.1
-mknotebooks==0.3.6
+git+git://github.com/lgeiger/mknotebooks@text-output-code
 mkdocs-minify-plugin==0.3.0
 larq-zoo==1.0.1
 altair==4.1.0


### PR DESCRIPTION
Closes #87 

Before: https://docs.larq.dev/larq/tutorials/mnist/
After: https://docs-mw7c2q9nn.now.sh/larq/tutorials/mnist/

This currently relies on a forked version of mknotebooks since https://github.com/greenape/mknotebooks/pull/28 is awaiting review.