### PR TITLE
Add Python 3.8 support to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ model = MyModel()
 
 Before installing Larq, please install:
 
-- [Python](https://www.python.org) version `3.6` or `3.7`
+- [Python](https://www.python.org) version `3.6`, `3.7` or `3.8`
 - [Tensorflow](https://www.tensorflow.org/install) version `1.14`, `1.15`, `2.0`, `2.1` or `2.2`:
   ```shell
   pip install tensorflow  # or tensorflow-gpu


### PR DESCRIPTION
Since it's been in the CI matrix since larq/larq#469, I think we can add this to the docs as well.