### PR TITLE
Make note about 32 vs 64-bit RPi OS more prominent

### DIFF
--- a/docs/compute-engine/build_arm.md
+++ b/docs/compute-engine/build_arm.md
@@ -22,10 +22,11 @@ This guide will show you how to build the [LCE example program](https://github.c
 See [here](/compute-engine/inference/) to find out how you can create your own LCE
 inference binary.
 
-NOTE: Although the Raspberry Pi 3 and Raspberry Pi 4 have 64-bit CPUs, the
-officially supported OS Raspbian for the Raspberry Pi is a 32-bit OS. In order
-to use the optimized 64-bit kernels of LCE on a Raspberry Pi, a 64-bit OS such
-as [Manjaro](https://manjaro.org/download/#raspberry-pi-4-xfce) should be used.
+!!! warning
+    Although the Raspberry Pi 3 and Raspberry Pi 4 have 64-bit CPUs, the
+    officially supported OS Raspbian for the Raspberry Pi is a 32-bit OS. In order
+    to use the optimized 64-bit kernels of LCE on a Raspberry Pi, a 64-bit OS such
+    as [Manjaro](https://manjaro.org/download/#raspberry-pi-4-xfce) should be used.
 
 ## Cross-compiling LCE with Bazel
 


### PR DESCRIPTION
It looks like https://github.com/larq/larq/issues/496 and https://github.com/larq/compute-engine/issues/383 might be caused by this confusion so let's make the note in our docs more prominent:
<img width="715" alt="Screenshot 2020-05-28 at 13 32 34" src="https://user-images.githubusercontent.com/13285808/83141499-b606a600-a0e7-11ea-9b97-333f5a63ed0d.png">
