### PR TITLE
Disable model summaries during development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Serve docs locally:
 ```shell
 ./download_lce_readme.sh
 python generate_docs.py
-python -m mkdocs serve
+IGNORE_MODEL_SUMMARIES=1 python -m mkdocs serve
 ```
 ## Build documentation locally using `npm`
 

--- a/model_summary.py
+++ b/model_summary.py
@@ -3,16 +3,21 @@ import larq_zoo as lqz
 import larq as lq
 import io
 from functools import reduce
+import os
 
+def _generate_html(code):
+    return f"""
+    <details class="abstract"
+      ><summary>Model Summary</summary>
+      <pre class="model-summary"><code>{code}</code></pre>
+    </details>
+    """
 
 def html_format(source, language=None, css_class=None, options=None, md=None, **kwargs):
+    if os.getenv("IGNORE_MODEL_SUMMARIES"):
+        return _generate_html("placeholder")
     model_fn = reduce(getattr, [lqz, *source.split(".")])
     stream = io.StringIO()
     tf.keras.backend.clear_session()
     lq.models.summary(model_fn(weights=None), print_fn=lambda s: print(s, file=stream))
-    return f"""
-    <details class="abstract"
-      ><summary>Model Summary</summary>
-      <pre class="model-summary"><code>{stream.getvalue()}</code></pre>
-    </details>
-    """
+    return _generate_html(stream.getvalue())

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "prebuild": "./download_lce_readme.sh && python3 generate_docs.py",
     "build:docs": "python3 -m mkdocs build -d public",
     "build": "npm run build:docs && npm run build:docs",
-    "dev": "python3 -m mkdocs serve"
+    "dev": "IGNORE_MODEL_SUMMARIES=1 python3 -m mkdocs serve"
   }
 }


### PR DESCRIPTION
Gerneating model summaries can be very slow, so this PR disables this during interactive development which fixes livereloading.