### PR TITLE
Add LCE benchmarks for literature models

### DIFF
--- a/docs/zoo/index.md
+++ b/docs/zoo/index.md
@@ -26,27 +26,31 @@ The model definitions and the train loops are available in the [Larq Zoo reposit
 
 The [`sota`](/zoo/api/sota/) submodule contains these models:
 
-| Model                                         | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory  |
-| --------------------------------------------- | -------------- | -------------- | ---------- | ------- |
-| [QuickNet](/zoo/api/sota/#quicknet)           | 58.6 %         | 81.0 %         | 10 511 232 | 3.18 MB |
-| [QuickNetLarge](/zoo/api/sota/#quicknetlarge) | 62.7 %         | 84.0 %         | 11 819 136 | 4.49 MB |
-| [QuickNetXL](/zoo/api/sota/#quicknetxl)       | 67.0 %         | 87.3 %         | 22 058 368 | 6.22 MB |
+| Model                                         | Top-1 Accuracy | Top-5 Accuracy  | Memory   | Pixel 1 latency (1 thread) |
+| ----------------------------------------------| -------------- | --------------  | -------- | ---------------------------|
+| [QuickNet](/zoo/api/sota/#quicknet)           | 58.6 %         | 81.0 %          |  3.18 MB | 18.3 ms                    |
+| [QuickNetLarge](/zoo/api/sota/#quicknetlarge) | 62.7 %         | 84.0 %          |  4.49 MB | 27.6 ms                    |
+| [QuickNetXL](/zoo/api/sota/#quicknetxl)       | 67.0 %         | 87.3 %          |  6.22 MB | 48.1 ms                    |
 
 The [`literature`](/zoo/api/literature/) submodule contains the following models:
 
-| Model                                                                   | Top-1 Accuracy | Top-5 Accuracy | Parameters | Memory   |
-| ----------------------------------------------------------------------- | -------------- | -------------- | ---------- | -------- |
-| [RealToBinaryNet](/zoo/api/literature/#realtobinarynet)                 | 65.0 %         | 85.7 %         | 11 995 624 | 5.13 MB  |
-| [BinaryDenseNet45](/zoo/api/literature/#binarydensenet45)               | 64.6 %         | 85.2 %         | 13 889 512 | 7.35 MB  |
-| [BinaryDenseNet37Dilated](/zoo/api/literature/#binarydensenet37dilated) | 64.3 %         | 85.2 %         | 8 702 248  | 5.13 MB  |
-| [BinaryDenseNet37](/zoo/api/literature/#binarydensenet37)               | 62.9 %         | 84.2 %         | 8 702 248  | 5.13 MB  |
-| [MeliusNet22](/zoo/api/literature/#meliusnet22)                         | 62.4 %         | 83.9 %         | 6 944 584  | 3.88 MB  |
-| [BinaryDenseNet28](/zoo/api/literature/#binarydensenet28)               | 60.9 %         | 82.8 %         | 5 131 496  | 4.04 MB  |
-| [BinaryResNetE18](/zoo/api/literature/#binaryresnete18)                 | 58.3 %         | 80.8 %         | 11 689 640 | 4.00 MB  |
-| [Bi-Real Net](/zoo/api/literature/#birealnet)                           | 57.5 %         | 79.8 %         | 10 985 472 | 4.00 MB  |
-| [DoReFaNet](/zoo/api/literature/#dorefanet)                             | 53.4 %         | 76.5 %         | 62 394 440 | 22.80 MB |
-| [XNOR-Net](/zoo/api/literature/#xnornet)                                | 45.0 %         | 69.2 %         | 62 387 104 | 22.77 MB |
-| [Binary AlexNet](/zoo/api/literature/#binaryalexnet)                    | 36.3 %         | 61.5 %         | 61 848 720 | 7.45 MB  |
+| Model                                                                   | Top-1 Accuracy | Top-5 Accuracy | Memory   | Pixel 1 latency (1 thread) |
+| ------------------------------------------------------------------------| -------------- | -------------- | -------- | ---------------------------|
+| [RealToBinaryNet](/zoo/api/literature/#realtobinarynet)                 | 65.0 %         | 85.7 %         | 5.13 MB  | 51.3 ms                    |
+| [BinaryDenseNet45](/zoo/api/literature/#binarydensenet45)               | 64.6 %         | 85.2 %         | 7.35 MB  | 138.5 ms                   |
+| [BinaryDenseNet37Dilated](/zoo/api/literature/#binarydensenet37dilated) | 64.3 %         | 85.2 %         | 5.13 MB  | 182.9 ms                   |
+| [BinaryDenseNet37](/zoo/api/literature/#binarydensenet37)               | 62.9 %         | 84.2 %         | 5.13 MB  | 102.2 ms                   |
+| [MeliusNet22](/zoo/api/literature/#meliusnet22)                         | 62.4 %         | 83.9 %         | 3.88 MB  | 117.7 ms                   |
+| [BinaryDenseNet28](/zoo/api/literature/#binarydensenet28)               | 60.9 %         | 82.8 %         | 4.04 MB  | 90.0 ms                    |
+| [BinaryResNetE18](/zoo/api/literature/#binaryresnete18)                 | 58.3 %         | 80.8 %         | 4.00 MB  | 43.6 ms                    |
+| [Bi-Real Net](/zoo/api/literature/#birealnet)                           | 57.5 %         | 79.8 %         | 4.00 MB  | 43.4 ms                    |
+| [DoReFaNet](/zoo/api/literature/#dorefanet)                             | 53.4 %         | 76.5 %         | 22.80 MB | Unsupported[^1]            |
+| [XNOR-Net](/zoo/api/literature/#xnornet)                                | 45.0 %         | 69.2 %         | 22.77 MB | 34.9 ms                    |
+| [Binary AlexNet](/zoo/api/literature/#binaryalexnet)                    | 36.3 %         | 61.5 %         | 7.45 MB  | 44.3 ms                    |
+
+[^1]: DoReFaNet uses quantizers for which currently no optimized implemention is available in LCE.
+
+Models were benchmarked using [Larq Compute Engine](/compute-engine/) on a [Pixel 1 phone (2016)](https://support.google.com/pixelphone/answer/7158570?hl=en-GB), single-threaded.
 
 ## Installation
 

--- a/docs/zoo/index.md
+++ b/docs/zoo/index.md
@@ -50,7 +50,7 @@ The [`literature`](/zoo/api/literature/) submodule contains the following models
 | [XNOR-Net](/zoo/api/literature/#xnornet)                                | 45.0 %         | 69.2 %         | 22.77 MB   | 34.9 ms                          |
 | [Binary AlexNet](/zoo/api/literature/#binaryalexnet)                    | 36.3 %         | 61.5 %         | 7.45 MB    | 44.3 ms                          |
 
-[^1]: Benchmarked on July 20st, 2020.
+[^1]: Benchmarked on July 20th, 2020.
 [^2]: DoReFaNet uses quantizers for which currently no optimized implemention is available in Larq Compute Engine.
 
 

--- a/docs/zoo/index.md
+++ b/docs/zoo/index.md
@@ -22,33 +22,33 @@ _Larq Zoo is part of a family of libraries for BNN development; you can also che
 
 The following models are trained on the [ImageNet](http://image-net.org/) dataset.
 The Top-1 and Top-5 accuracy refers to the model's performance on the ImageNet validation dataset, memory refers to the memory after quantization of the weights.
-Models were benchmarked using [Larq Compute Engine](/compute-engine/) on a [Pixel 1 phone (2016)](https://support.google.com/pixelphone/answer/7158570?hl=en-GB), single-threaded.
+Models were benchmarked using [Larq Compute Engine](/compute-engine/) on a [Pixel 1 phone (2016)](https://support.google.com/pixelphone/answer/7158570?hl=en-GB), single-threaded[^1].
 
 The model definitions and the train loops are available in the [Larq Zoo repository](https://github.com/larq/zoo).
 
 The [`sota`](/zoo/api/sota/) submodule contains these models:
 
-| Model                                         | Top-1 Accuracy | Top-5 Accuracy  | Model size | Latency (Pixel 1, single thread)[^1] |
-| --------------------------------------------- | -------------- | --------------  | ---------- | ------------------------------------ |
-| [QuickNet](/zoo/api/sota/#quicknet)           | 58.6 %         | 81.0 %          |  3.18 MB   | 18.4 ms                              |
-| [QuickNetLarge](/zoo/api/sota/#quicknetlarge) | 62.7 %         | 84.0 %          |  4.49 MB   | 27.6 ms                              |
-| [QuickNetXL](/zoo/api/sota/#quicknetxl)       | 67.0 %         | 87.3 %          |  6.22 MB   | 47.9 ms                              |
+| Model                                         | Top-1 Accuracy | Top-5 Accuracy  | Model size | Latency (Pixel 1, single thread) |
+| --------------------------------------------- | -------------- | --------------  | ---------- | -------------------------------- |
+| [QuickNet](/zoo/api/sota/#quicknet)           | 58.6 %         | 81.0 %          |  3.18 MB   | 18.4 ms                          |
+| [QuickNetLarge](/zoo/api/sota/#quicknetlarge) | 62.7 %         | 84.0 %          |  4.49 MB   | 27.6 ms                          |
+| [QuickNetXL](/zoo/api/sota/#quicknetxl)       | 67.0 %         | 87.3 %          |  6.22 MB   | 47.9 ms                          |
 
 The [`literature`](/zoo/api/literature/) submodule contains the following models:
 
-| Model                                                                   | Top-1 Accuracy | Top-5 Accuracy | Model size | Latency (Pixel 1, single thread)[^1] |
-| ----------------------------------------------------------------------- | -------------- | -------------- | ---------- | ------------------------------------ |
-| [RealToBinaryNet](/zoo/api/literature/#realtobinarynet)                 | 65.0 %         | 85.7 %         | 5.13 MB    | 51.3 ms                              |
-| [BinaryDenseNet45](/zoo/api/literature/#binarydensenet45)               | 64.6 %         | 85.2 %         | 7.35 MB    | 138.5 ms                             |
-| [BinaryDenseNet37Dilated](/zoo/api/literature/#binarydensenet37dilated) | 64.3 %         | 85.2 %         | 5.13 MB    | 182.9 ms                             |
-| [BinaryDenseNet37](/zoo/api/literature/#binarydensenet37)               | 62.9 %         | 84.2 %         | 5.13 MB    | 102.2 ms                             |
-| [MeliusNet22](/zoo/api/literature/#meliusnet22)                         | 62.4 %         | 83.9 %         | 3.88 MB    | 117.7 ms                             |
-| [BinaryDenseNet28](/zoo/api/literature/#binarydensenet28)               | 60.9 %         | 82.8 %         | 4.04 MB    | 90.0 ms                              |
-| [BinaryResNetE18](/zoo/api/literature/#binaryresnete18)                 | 58.3 %         | 80.8 %         | 4.00 MB    | 43.6 ms                              |
-| [Bi-Real Net](/zoo/api/literature/#birealnet)                           | 57.5 %         | 79.8 %         | 4.00 MB    | 43.4 ms                              |
-| [DoReFaNet](/zoo/api/literature/#dorefanet)                             | 53.4 %         | 76.5 %         | 22.80 MB   | Unsupported[^2]                      |
-| [XNOR-Net](/zoo/api/literature/#xnornet)                                | 45.0 %         | 69.2 %         | 22.77 MB   | 34.9 ms                              |
-| [Binary AlexNet](/zoo/api/literature/#binaryalexnet)                    | 36.3 %         | 61.5 %         | 7.45 MB    | 44.3 ms                              |
+| Model                                                                   | Top-1 Accuracy | Top-5 Accuracy | Model size | Latency (Pixel 1, single thread) |
+| ----------------------------------------------------------------------- | -------------- | -------------- | ---------- | -------------------------------- |
+| [RealToBinaryNet](/zoo/api/literature/#realtobinarynet)                 | 65.0 %         | 85.7 %         | 5.13 MB    | 51.3 ms                          |
+| [BinaryDenseNet45](/zoo/api/literature/#binarydensenet45)               | 64.6 %         | 85.2 %         | 7.35 MB    | 138.5 ms                         |
+| [BinaryDenseNet37Dilated](/zoo/api/literature/#binarydensenet37dilated) | 64.3 %         | 85.2 %         | 5.13 MB    | 182.9 ms                         |
+| [BinaryDenseNet37](/zoo/api/literature/#binarydensenet37)               | 62.9 %         | 84.2 %         | 5.13 MB    | 102.2 ms                         |
+| [MeliusNet22](/zoo/api/literature/#meliusnet22)                         | 62.4 %         | 83.9 %         | 3.88 MB    | 117.7 ms                         |
+| [BinaryDenseNet28](/zoo/api/literature/#binarydensenet28)               | 60.9 %         | 82.8 %         | 4.04 MB    | 90.0 ms                          |
+| [BinaryResNetE18](/zoo/api/literature/#binaryresnete18)                 | 58.3 %         | 80.8 %         | 4.00 MB    | 43.6 ms                          |
+| [Bi-Real Net](/zoo/api/literature/#birealnet)                           | 57.5 %         | 79.8 %         | 4.00 MB    | 43.4 ms                          |
+| [DoReFaNet](/zoo/api/literature/#dorefanet)                             | 53.4 %         | 76.5 %         | 22.80 MB   | Unsupported[^2]                  |
+| [XNOR-Net](/zoo/api/literature/#xnornet)                                | 45.0 %         | 69.2 %         | 22.77 MB   | 34.9 ms                          |
+| [Binary AlexNet](/zoo/api/literature/#binaryalexnet)                    | 36.3 %         | 61.5 %         | 7.45 MB    | 44.3 ms                          |
 
 [^1]: Benchmarked on July 20st, 2020.
 [^2]: DoReFaNet uses quantizers for which currently no optimized implemention is available in Larq Compute Engine.

--- a/docs/zoo/index.md
+++ b/docs/zoo/index.md
@@ -20,37 +20,39 @@ _Larq Zoo is part of a family of libraries for BNN development; you can also che
 
 ## Available models
 
-The following models are trained on the [ImageNet](http://image-net.org/) dataset. The Top-1 and Top-5 accuracy refers to the model's performance on the ImageNet validation dataset, memory refers to the memory after quantization of the weights.
+The following models are trained on the [ImageNet](http://image-net.org/) dataset.
+The Top-1 and Top-5 accuracy refers to the model's performance on the ImageNet validation dataset, memory refers to the memory after quantization of the weights.
+Models were benchmarked using [Larq Compute Engine](/compute-engine/) on a [Pixel 1 phone (2016)](https://support.google.com/pixelphone/answer/7158570?hl=en-GB), single-threaded.
 
 The model definitions and the train loops are available in the [Larq Zoo repository](https://github.com/larq/zoo).
 
 The [`sota`](/zoo/api/sota/) submodule contains these models:
 
-| Model                                         | Top-1 Accuracy | Top-5 Accuracy  | Memory   | Pixel 1 latency (1 thread) |
-| ----------------------------------------------| -------------- | --------------  | -------- | ---------------------------|
-| [QuickNet](/zoo/api/sota/#quicknet)           | 58.6 %         | 81.0 %          |  3.18 MB | 18.3 ms                    |
-| [QuickNetLarge](/zoo/api/sota/#quicknetlarge) | 62.7 %         | 84.0 %          |  4.49 MB | 27.6 ms                    |
-| [QuickNetXL](/zoo/api/sota/#quicknetxl)       | 67.0 %         | 87.3 %          |  6.22 MB | 48.1 ms                    |
+| Model                                         | Top-1 Accuracy | Top-5 Accuracy  | Model size | Pixel 1 latency (1 thread)[^1] |
+| --------------------------------------------- | -------------- | --------------  | ---------- | ------------------------------ |
+| [QuickNet](/zoo/api/sota/#quicknet)           | 58.6 %         | 81.0 %          |  3.18 MB   | 18.4 ms                        |
+| [QuickNetLarge](/zoo/api/sota/#quicknetlarge) | 62.7 %         | 84.0 %          |  4.49 MB   | 27.6 ms                        |
+| [QuickNetXL](/zoo/api/sota/#quicknetxl)       | 67.0 %         | 87.3 %          |  6.22 MB   | 47.9 ms                        |
 
 The [`literature`](/zoo/api/literature/) submodule contains the following models:
 
-| Model                                                                   | Top-1 Accuracy | Top-5 Accuracy | Memory   | Pixel 1 latency (1 thread) |
-| ------------------------------------------------------------------------| -------------- | -------------- | -------- | ---------------------------|
-| [RealToBinaryNet](/zoo/api/literature/#realtobinarynet)                 | 65.0 %         | 85.7 %         | 5.13 MB  | 51.3 ms                    |
-| [BinaryDenseNet45](/zoo/api/literature/#binarydensenet45)               | 64.6 %         | 85.2 %         | 7.35 MB  | 138.5 ms                   |
-| [BinaryDenseNet37Dilated](/zoo/api/literature/#binarydensenet37dilated) | 64.3 %         | 85.2 %         | 5.13 MB  | 182.9 ms                   |
-| [BinaryDenseNet37](/zoo/api/literature/#binarydensenet37)               | 62.9 %         | 84.2 %         | 5.13 MB  | 102.2 ms                   |
-| [MeliusNet22](/zoo/api/literature/#meliusnet22)                         | 62.4 %         | 83.9 %         | 3.88 MB  | 117.7 ms                   |
-| [BinaryDenseNet28](/zoo/api/literature/#binarydensenet28)               | 60.9 %         | 82.8 %         | 4.04 MB  | 90.0 ms                    |
-| [BinaryResNetE18](/zoo/api/literature/#binaryresnete18)                 | 58.3 %         | 80.8 %         | 4.00 MB  | 43.6 ms                    |
-| [Bi-Real Net](/zoo/api/literature/#birealnet)                           | 57.5 %         | 79.8 %         | 4.00 MB  | 43.4 ms                    |
-| [DoReFaNet](/zoo/api/literature/#dorefanet)                             | 53.4 %         | 76.5 %         | 22.80 MB | Unsupported[^1]            |
-| [XNOR-Net](/zoo/api/literature/#xnornet)                                | 45.0 %         | 69.2 %         | 22.77 MB | 34.9 ms                    |
-| [Binary AlexNet](/zoo/api/literature/#binaryalexnet)                    | 36.3 %         | 61.5 %         | 7.45 MB  | 44.3 ms                    |
+| Model                                                                   | Top-1 Accuracy | Top-5 Accuracy | Model size | Pixel 1 latency (1 thread)[^1] |
+| ----------------------------------------------------------------------- | -------------- | -------------- | ---------- | ------------------------------ |
+| [RealToBinaryNet](/zoo/api/literature/#realtobinarynet)                 | 65.0 %         | 85.7 %         | 5.13 MB    | 51.3 ms                        |
+| [BinaryDenseNet45](/zoo/api/literature/#binarydensenet45)               | 64.6 %         | 85.2 %         | 7.35 MB    | 138.5 ms                       |
+| [BinaryDenseNet37Dilated](/zoo/api/literature/#binarydensenet37dilated) | 64.3 %         | 85.2 %         | 5.13 MB    | 182.9 ms                       |
+| [BinaryDenseNet37](/zoo/api/literature/#binarydensenet37)               | 62.9 %         | 84.2 %         | 5.13 MB    | 102.2 ms                       |
+| [MeliusNet22](/zoo/api/literature/#meliusnet22)                         | 62.4 %         | 83.9 %         | 3.88 MB    | 117.7 ms                       |
+| [BinaryDenseNet28](/zoo/api/literature/#binarydensenet28)               | 60.9 %         | 82.8 %         | 4.04 MB    | 90.0 ms                        |
+| [BinaryResNetE18](/zoo/api/literature/#binaryresnete18)                 | 58.3 %         | 80.8 %         | 4.00 MB    | 43.6 ms                        |
+| [Bi-Real Net](/zoo/api/literature/#birealnet)                           | 57.5 %         | 79.8 %         | 4.00 MB    | 43.4 ms                        |
+| [DoReFaNet](/zoo/api/literature/#dorefanet)                             | 53.4 %         | 76.5 %         | 22.80 MB   | Unsupported[^2]                |
+| [XNOR-Net](/zoo/api/literature/#xnornet)                                | 45.0 %         | 69.2 %         | 22.77 MB   | 34.9 ms                        |
+| [Binary AlexNet](/zoo/api/literature/#binaryalexnet)                    | 36.3 %         | 61.5 %         | 7.45 MB    | 44.3 ms                        |
 
-[^1]: DoReFaNet uses quantizers for which currently no optimized implemention is available in LCE.
+[^1]: Benchmarked on July 20st, 2020.
+[^2]: DoReFaNet uses quantizers for which currently no optimized implemention is available in LCE.
 
-Models were benchmarked using [Larq Compute Engine](/compute-engine/) on a [Pixel 1 phone (2016)](https://support.google.com/pixelphone/answer/7158570?hl=en-GB), single-threaded.
 
 ## Installation
 


### PR DESCRIPTION
This adds LCE benchmarks for literature models on the Pixel 1 (single-threaded). To keep the tables readable, I've removed the parameter count.