### PR TITLE
Add `/public` to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ docs/compute-engine/index.md
 docs/plots/generated
 docs/*/api
 package-lock.json
+public
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
`npm run dev` generates a `public/` directory with build assets, that we probably want to exclude.