### PR TITLE
[LCE] Restructure Android guide into different parts

### DIFF
--- a/docs/compute-engine/build_android.md
+++ b/docs/compute-engine/build_android.md
@@ -56,9 +56,7 @@ For example, to build the [minimal example](https://github.com/larq/compute-engi
 run the following command from the LCE root directory:
 
 ```bash
-bazel build -c opt \
-    --config=android_arm64 \
-    //examples:lce_minimal
+bazel build -c opt --config=android_arm64 //examples:lce_minimal
 ```
 
 To build the [LCE benchmark tool](https://github.com/larq/compute-engine/tree/master/larq_compute_engine/tflite/benchmark)

--- a/docs/compute-engine/build_android.md
+++ b/docs/compute-engine/build_android.md
@@ -15,7 +15,7 @@ NOTE: we recommend using the docker volume as described in the
 [LCE build guide](/compute-engine/build/) to be able to easily transfer
 files in-between the container and the host machine.
 
-##### Install prerequisites #####
+## Install prerequisites
 
 We provide a bash script which uses the `sdkmanager` tool
 to install the Android NDK and SDK inside the Docker container.

--- a/docs/compute-engine/build_android.md
+++ b/docs/compute-engine/build_android.md
@@ -48,7 +48,7 @@ build --action_env ANDROID_SDK_API_LEVEL="29"
 build --action_env ANDROID_SDK_HOME="/tmp/lce_android"
 ```
 
-### Build an LCE inference or benchmark binary ###
+## Build an LCE inference or benchmark binary
 
 To build an LCE inference binary for Android (see [here](/compute-engine/inference/) for creating your
 own LCE binary) the Bazel target needs to built with `--config=android_arm64` flag.

--- a/docs/compute-engine/build_android.md
+++ b/docs/compute-engine/build_android.md
@@ -1,0 +1,75 @@
+## Create an LCE inference binary for Android ##
+To build Larq Compute Engine (LCE) for Android,
+you must have the [Android NDK](https://developer.android.com/ndk) and
+[SDK](https://developer.android.com/studio) installed on your system.
+Below we explain how to install the Android prerequisites in the LCE
+Docker container and how to configure the LCE Bazel build settings
+accordingly. Before proceeding with the next steps, please follow
+the instructions in the main [LCE build guide](/compute-engine/build/) to setup
+the Docker container for LCE and the Bazel build system.
+
+NOTE: we recommend using the docker volume as described in the
+[LCE build guide](/compute-engine/build/) to be able to easily transfer
+files in-between the container and the host machine.
+
+##### Install prerequisites #####
+
+We provide a bash script which uses the `sdkmanager` tool
+to install the Android NDK and SDK inside the Docker container.
+Please run the script by executing the following command from the LCE
+root directory:
+
+```bash
+./third_party/install_android.sh
+```
+
+After executing the bash script, please accept the Android SDK licence agreement.
+The script will download and unpack the Android NDK and SKD under the directory
+`/tmp/lce_android` in the LCE docker container.
+
+##### Custom android version #####
+
+The Android NDK and SDK versions used in LCE are currently hard-coded in the
+install script.
+To build LCE against a different NDK and SDK versions, you can manually
+modify `ANDROID_VERSION` and `ANDROID_NDK_VERSION` variables in the
+install script. Additionally, the following configurations in `configure.sh`
+(or `.bazelrc`) file need to be adjusted:
+
+```shell
+build --action_env ANDROID_NDK_HOME="/tmp/lce_android/ndk/19.2.5345600"
+build --action_env ANDROID_NDK_API_LEVEL="21"
+build --action_env ANDROID_BUILD_TOOLS_VERSION="28.0.3"
+build --action_env ANDROID_SDK_API_LEVEL="23"
+build --action_env ANDROID_SDK_HOME="/usr/local/android/android-sdk-linux"
+```
+
+### Build an LCE inference or benchmark binary ###
+
+To build an LCE inference binary for Android (see [here](/compute-engine/inference/) for creating your
+own LCE binary) the Bazel target needs to built with `--config=android_arm64` flag.
+For example, to build the [minimal example](https://github.com/larq/compute-engine/blob/master/examples/lce_minimal.cc) for Android,
+run the following command from the LCE root directory:
+
+```bash
+bazel build -c opt \
+    --config=android_arm64 \
+    //examples:lce_minimal
+```
+
+To build the [LCE benchmark tool](https://github.com/larq/compute-engine/tree/master/larq_compute_engine/tflite/benchmark)
+for Android, simply build the bazel target
+`//larq_compute_engine/tflite/benchmark:lce_benchmark_model`.
+
+The resulting binaries will be stored at
+`bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model`
+and `bazel-bin/examples/lce_minimal`.
+The `bazel-bin` directory inside the `lce-volume` is a soft link to
+the build artifacts directory outside the `lce-volume`.
+As a result, in order to be able to access the inference binaries on the host machine,
+you need to manually copy them from the `bazel-bin` to the `lce-volume` directory.
+To do so, run the following command from the LCE root directory:
+
+```bash
+cp bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model .
+```

--- a/docs/compute-engine/build_android.md
+++ b/docs/compute-engine/build_android.md
@@ -1,6 +1,6 @@
 ## Create an LCE inference binary for Android ##
 !!! note
-    This guide explains how to build standalone inference binary that can be executed on Android OS. If you'd rather use LCE for inference as part of your own Android app, please check out [this guide](/compute-engine/quickstart_android) instead.
+    This guide explains how to build a standalone inference binary that can be executed on an Android device using the [Android developer tools](https://developer.android.com/studio/command-line/adb#shellcommands). If you'd rather use LCE for inference as part of an Android app, please check out [this guide](/compute-engine/quickstart_android) instead.
 
 To build Larq Compute Engine (LCE) for Android,
 you must have the [Android NDK](https://developer.android.com/ndk) and

--- a/docs/compute-engine/build_android.md
+++ b/docs/compute-engine/build_android.md
@@ -31,7 +31,7 @@ After executing the bash script, please accept the Android SDK licence agreement
 The script will download and unpack the Android NDK and SKD under the directory
 `/tmp/lce_android` in the LCE docker container.
 
-##### Custom android version #####
+## Custom Android version
 
 The Android NDK and SDK versions used in LCE are currently hard-coded in the
 install script.

--- a/docs/compute-engine/build_android.md
+++ b/docs/compute-engine/build_android.md
@@ -1,4 +1,7 @@
 ## Create an LCE inference binary for Android ##
+!!! note
+    This guide explains how to build standalone inference binary that can be executed on Android OS. If you'd rather use LCE for inference as part of your own Android app, please check out [this guide](/compute-engine/quickstart_android) instead.
+
 To build Larq Compute Engine (LCE) for Android,
 you must have the [Android NDK](https://developer.android.com/ndk) and
 [SDK](https://developer.android.com/studio) installed on your system.

--- a/docs/compute-engine/build_android.md
+++ b/docs/compute-engine/build_android.md
@@ -36,15 +36,15 @@ The Android NDK and SDK versions used in LCE are currently hard-coded in the
 install script.
 To build LCE against a different NDK and SDK versions, you can manually
 modify `ANDROID_VERSION` and `ANDROID_NDK_VERSION` variables in the
-install script. Additionally, the following configurations in `configure.sh`
-(or `.bazelrc`) file need to be adjusted:
+install script. Additionally, the following configurations in the `.bazelrc`
+file need to be adjusted:
 
 ```shell
-build --action_env ANDROID_NDK_HOME="/tmp/lce_android/ndk/19.2.5345600"
+build --action_env ANDROID_NDK_HOME="/tmp/lce_android/ndk/18.1.5063045"
 build --action_env ANDROID_NDK_API_LEVEL="21"
 build --action_env ANDROID_BUILD_TOOLS_VERSION="28.0.3"
-build --action_env ANDROID_SDK_API_LEVEL="23"
-build --action_env ANDROID_SDK_HOME="/usr/local/android/android-sdk-linux"
+build --action_env ANDROID_SDK_API_LEVEL="29"
+build --action_env ANDROID_SDK_HOME="/tmp/lce_android"
 ```
 
 ### Build an LCE inference or benchmark binary ###

--- a/docs/compute-engine/build_android.md
+++ b/docs/compute-engine/build_android.md
@@ -12,9 +12,10 @@ accordingly. Before proceeding with the next steps, please follow
 the instructions in the main [LCE build guide](/compute-engine/build/) to setup
 the Docker container for LCE and the Bazel build system.
 
-NOTE: we recommend using the docker volume as described in the
-[LCE build guide](/compute-engine/build/) to be able to easily transfer
-files in-between the container and the host machine.
+!!! note
+    We recommend using the docker volume as described in the
+    [LCE build guide](/compute-engine/build/) to be able to easily transfer
+    files in-between the container and the host machine.
 
 ## Install prerequisites
 

--- a/docs/compute-engine/build_android.md
+++ b/docs/compute-engine/build_android.md
@@ -1,6 +1,6 @@
 # Create an LCE inference binary for Android
 
-!!! note
+!!! important
     This guide explains how to build a standalone inference binary that can be executed on an Android device using the [Android developer tools](https://developer.android.com/studio/command-line/adb#shellcommands). If you'd rather use LCE for inference as part of an Android app, please check out [this guide](/compute-engine/quickstart_android) instead.
 
 To build Larq Compute Engine (LCE) for Android,

--- a/docs/compute-engine/build_android.md
+++ b/docs/compute-engine/build_android.md
@@ -1,4 +1,5 @@
-## Create an LCE inference binary for Android ##
+# Create an LCE inference binary for Android
+
 !!! note
     This guide explains how to build a standalone inference binary that can be executed on an Android device using the [Android developer tools](https://developer.android.com/studio/command-line/adb#shellcommands). If you'd rather use LCE for inference as part of an Android app, please check out [this guide](/compute-engine/quickstart_android) instead.
 

--- a/docs/compute-engine/quickstart_android.md
+++ b/docs/compute-engine/quickstart_android.md
@@ -38,7 +38,7 @@ in detail in the following sections.
     Modify the `build.gradle` file in the Android project to include the
     `lce-lite` dependency:
 
-    ```
+    ```gradle
     allprojects {
         repositories {
             maven {

--- a/docs/compute-engine/quickstart_android.md
+++ b/docs/compute-engine/quickstart_android.md
@@ -89,7 +89,7 @@ in detail in the following sections.
     Modify the `build.gradle` file in the the Android project to
     include `mavenLocal()` repository:
 
-    ```
+    ```gradle
     allprojects {
         repositories {
             jcenter()

--- a/docs/compute-engine/quickstart_android.md
+++ b/docs/compute-engine/quickstart_android.md
@@ -3,7 +3,7 @@
 This guide describes how to build your own Android app using Larq Compute Engine (LCE) and
 [TensorFlow Lite Java Inference APIs](https://www.tensorflow.org/lite/guide/inference#load_and_run_a_model_in_java)
 to perform inference with a model built and trained with [Larq](https://larq.dev).
-This can be achieved either by using our pre-built [LCE Lite AAR hosted on Bintray](https://bintray.com/plumeraihq/larq-compute-engine), or you can build the LCE Lite AAR on your local machine (see [here](2-add-lce-compatible-tensorflow-lite-aar-to-the-project) for instructions for either approach).
+This can be achieved either by using our pre-built [LCE Lite AAR hosted on Bintray](https://bintray.com/plumeraihq/larq-compute-engine), or you can build the LCE Lite AAR on your local machine (see [here](#2-add-lce-compatible-tensorflow-lite-aar-to-the-project) for instructions for either approach).
 
 If you'd rather build a binary than a full Android app, [this guide](/compute-engine/build_android) describes how to build
 a LCE-compatible inference binary that can be executed on Android OS (e.g to [benchmark your models](/compute-engine/benchmark)).

--- a/docs/compute-engine/quickstart_android.md
+++ b/docs/compute-engine/quickstart_android.md
@@ -6,8 +6,7 @@ to perform inference with a model built and trained with [Larq](https://larq.dev
 This can be achieved either by using our pre-built [LCE Lite AAR hosted on Bintray](https://bintray.com/plumeraihq/larq-compute-engine), or you can build the LCE Lite AAR on your local machine (see [here](2-add-lce-compatible-tensorflow-lite-aar-to-the-project) for instructions for either approach).
 
 If you'd rather build a binary than a full Android app, [this guide](/compute-engine/build_android) describes how to build
-a LCE-compatible inference binary that can be executed on Android OS
-(e.g, a binary to benchmark your models).
+a LCE-compatible inference binary that can be executed on Android OS (e.g to [benchmark your models](/compute-engine/benchmark)).
 
 ## Create Your Own Android app using LCE and TensorFlow Lite ##
 In this section, we demonstrate how to perform inference with a Larq model in an
@@ -128,8 +127,7 @@ in detail in the following sections.
 
 In this guide, we use the Larq [QuickNet](/zoo/api/sota/#quicknet)
 model for efficient and fast image classification. The FlatBuffer format of the QuickNet model
-`quicknet.tflite` can be created by using the [LCE converter](/compute-engine/api/converter/)
-and needs to be placed in the `assets` folder of the Android project.
+`quicknet.tflite` can be created by using the [LCE converter](/compute-engine/api/converter/) (also see our [Model Conversion and Benchmarking Guide](/comppute-engine/end_to_end)) and needs to be placed in the `assets` folder of the Android project.
 You also need to use the `labels_without_background.txt` as its corresponding labels file.
 The labels file is already available in the `asset` folder of
 the TensorFlow Lite image classification Android app.

--- a/docs/compute-engine/quickstart_android.md
+++ b/docs/compute-engine/quickstart_android.md
@@ -101,7 +101,7 @@ in detail in the following sections.
     Replace the standard TensorFlow Lite dependency with
     local LCE Lite AAR:
 
-    ```
+    ```gradle
     dependencies {
         implementation 'org.larq:lce-lite:0.1.000'
     }

--- a/docs/compute-engine/quickstart_android.md
+++ b/docs/compute-engine/quickstart_android.md
@@ -115,7 +115,7 @@ in detail in the following sections.
     the standard TensorFlow Lite dependency by commenting out the following
     line in `build.gradle` file:
 
-    ```
+    ```gradle
     dependencies {
         // Comment out the following line
         // implementation 'org.tensorflow:tensorflow-lite:0.0.0-nightly'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
           # TODO: Restructure (build benchmarking binaries, build converter)
           - Build from source: compute-engine/build.md
           - Build for ARM: compute-engine/build_arm.md
+          - Build for Android: compute-engine/build_android.md
       - API:
         - Python Converter: compute-engine/api/converter.md
         - TFLite Operators: compute-engine/api/operators.md


### PR DESCRIPTION
Moves the part about building a binary under the "building from source" section of the docs, moves the "using the pre-built AAR" and "building AAR locally" sections under a switchable tab, and adds some cross-references to other guides such as #176 