### PR TITLE
Split different build methods on ARM into different tabs

### DIFF
--- a/docs/compute-engine/build/arm.md
+++ b/docs/compute-engine/build/arm.md
@@ -7,150 +7,154 @@ be used to cross-compile binaries for ARM architectures directly from the host.
 To natively build on an ARM system, we provide a solution based on the
 Makefile build system.
 
-This leaves us with three ways to build LCE binaries, which we recommend in
-the following order:
-
-1. To cross-compile LCE from a host machine, see
-   [Cross-compiling LCE with Bazel](#cross-compiling-lce-with-bazel)
-2. To natively compile LCE, see
-   [Building LCE with Make](#building-lce-with-make).
-3. To cross-compile LCE using the Make system for users that do not wish to
-   install Bazel, see
-   [Cross-compiling LCE with Make](#cross-compiling-lce-with-make).
-
-This guide will show you how to build the [LCE example program](https://github.com/larq/compute-engine/blob/master/examples/lce_minimal.cc).
-See [here](/compute-engine/inference/) to find out how you can create your own LCE
-inference binary.
-
 !!! warning
     Although the Raspberry Pi 3 and Raspberry Pi 4 have 64-bit CPUs, the
     officially supported OS Raspbian for the Raspberry Pi is a 32-bit OS. In order
     to use the optimized 64-bit kernels of LCE on a Raspberry Pi, a 64-bit OS such
     as [Manjaro](https://manjaro.org/download/#raspberry-pi-4-xfce) should be used.
 
-## Cross-compiling LCE with Bazel
+This leaves us with three ways to build LCE binaries, which we recommend in
+the following order:
 
-For cross-compiling on a Mac host, a docker image is required.
-Please see [setting up Docker](/compute-engine/build/docker/) for instructions on
-setting up the docker container, and then follow continue the steps here.
+1. To cross-compile LCE from a host machine, see "Cross-compiling with Bazel".
+2. To natively compile LCE, see "Building with Make".
+3. To cross-compile LCE using the Make system for users that do not wish to
+   install Bazel, see "Cross-compiling with Make".
 
-To cross-compile the LCE example for ARM architectures, the bazel
-target needs to be built with the `--config=rpi3` (32-bit ARM) or
-`--config=aarch64` (64-bit ARM) flag. For example, to build the example
-for 64-bit ARM systems, run the following command from the LCE root
-directory:
+This guide will show you how to build the [LCE example program](https://github.com/larq/compute-engine/blob/master/examples/lce_minimal.cc).
+See [here](/compute-engine/inference/) to find out how you can create your own LCE
+inference binary.
 
-```bash
-bazel build --config=aarch64 //examples:lce_minimal
-```
+=== "Cross-compiling with Bazel"
 
-To build the LCE benchmark tool, build the bazel target
-`//larq_compute_engine/tflite/benchmark:lce_benchmark_model`
+    For cross-compiling on a Mac host, a docker image is required.
+    Please see [setting up Docker](/compute-engine/build/docker/) for instructions on
+    setting up the docker container, and then follow continue the steps here.
 
-The resulting binaries will be stored at
-`bazel-bin/examples/lce_minimal` and
-`bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model`. You can
-copy these to your ARM machine and run them there.
-
-## Building LCE with Make
-
-To build LCE with Make, first clone the Larq Compute Engine repository and make
-sure the tensorflow submodule is loaded:
-
-```bash
-git submodule update --init
-```
-
-To simplify the build process for various supported targets, we provide the
-`build_lce.sh` script which accepts the build target platform as an input
-argument.
-
-To natively build the LCE library and C++ example programs, first you need to
-install the compiler toolchain on your target device.
-
-=== "Linux (Debian based)"
-    On Debian based systems like a
-    Raspberry Pi board with Raspbian, run the following command:
-
-    ```
-    sudo apt-get install build-essential
-    ```
-
-=== "Linux (Arch based)"
-    On an Arch based system like a Raspberry Pi board with Manjaro operating system, run the following command instead:
-
-    ```
-    sudo pacman -S base-devel
-    ```
-
-You should then be able to natively compile LCE by running the following from
-the LCE root directory:
-
-```bash
-larq_compute_engine/tflite/build_make/build_lce.sh --native
-```
-
-It is also possible to replace `--native` by `--rpi` (32-bit ARM) or
-`--aarch64` (64-bit ARM) to add extra compiler optimization flags.
-
-The resulting compiled files will be stored in
-`third_party/tensorflow/tensorflow/lite/tools/make/gen/<TARGET>` where,
-depending on your target platform, `<TARGET>` can be `linux_x86_64`,
-`rpi_armv7l`, or `aarch64_armv8-a`. In the `bin` folder, you can find the
-example program `lce_minimal` and benchmark program `benchmark_model`.
-In the `lib` folder, you can find the TensorFlow Lite static library
-`libtensorflow-lite.a` which includes the LCE customs ops.
-
-
-!!! note
-    On some systems the compiler is incorrectly named `aarch64-unknown-linux-gnu-gcc`
-    while it should be named `aarch64-linux-gnu-gcc`. If building with the option
-    `--aarch64` results in errors then the following bash script can be used to
-    create symlinks that fix this naming issue.
+    To cross-compile the LCE example for ARM architectures, the bazel
+    target needs to be built with the `--config=rpi3` (32-bit ARM) or
+    `--config=aarch64` (64-bit ARM) flag. For example, to build the example
+    for 64-bit ARM systems, run the following command from the LCE root
+    directory:
 
     ```bash
-    #!/usr/bin/env bash
-
-    cd /usr/bin
-    for unknownfile in aarch64-unknown-linux-gnu-*; do
-    	newfile="${unknownfile/-unknown-/-}"    
-    	echo "Creating symlink $newfile that points to $unknownfile"
-    	ln -s $unknownfile $newfile
-    done
+    bazel build --config=aarch64 //examples:lce_minimal
     ```
 
-## Cross-compiling LCE with Make
+    To build the LCE benchmark tool, build the bazel target
+    `//larq_compute_engine/tflite/benchmark:lce_benchmark_model`
 
-First clone the Larq Compute Engine repository and make sure the tensorflow
-submodule is loaded:
+    The resulting binaries will be stored at
+    `bazel-bin/examples/lce_minimal` and
+    `bazel-bin/larq_compute_engine/tflite/benchmark/lce_benchmark_model`. You can
+    copy these to your ARM machine and run them there.
 
-```bash
-git submodule update --init
-```
+=== "Building with Make"
 
-To cross-compile LCE, you need to first install the compiler toolchain:
+    To build LCE with Make, first clone the Larq Compute Engine repository and make
+    sure the tensorflow submodule is loaded:
 
-=== "Linux (Debian based)"
     ```bash
-    sudo apt-get update
-    sudo apt-get install crossbuild-essential-armhf
+    git submodule update --init
     ```
 
-=== "Linux (Arch based)"
+    To simplify the build process for various supported targets, we provide the
+    `build_lce.sh` script which accepts the build target platform as an input
+    argument.
+
+    To natively build the LCE library and C++ example programs, first you need to
+    install the compiler toolchain on your target device.
+
+    === "Linux (Debian based)"
+        On Debian based systems like a
+        Raspberry Pi board with Raspbian, run the following command:
+
+        ```
+        sudo apt-get install build-essential
+        ```
+
+    === "Linux (Arch based)"
+        On an Arch based system like a Raspberry Pi board with Manjaro operating system, run the following command instead:
+
+        ```
+        sudo pacman -S base-devel
+        ```
+
+    You should then be able to natively compile LCE by running the following from
+    the LCE root directory:
+
     ```bash
-    sudo pacman -Syy
-    sudo pacman -S arm-linux-gnueabihf
+    larq_compute_engine/tflite/build_make/build_lce.sh --native
     ```
 
-To build for 32-bit ARM architectures, run the following command from the LCE
-root directory:
+    It is also possible to replace `--native` by `--rpi` (32-bit ARM) or
+    `--aarch64` (64-bit ARM) to add extra compiler optimization flags.
 
-```bash
-larq_compute_engine/tflite/build_make/build_lce.sh --rpi
-```
+    The resulting compiled files will be stored in
+    `third_party/tensorflow/tensorflow/lite/tools/make/gen/<TARGET>` where,
+    depending on your target platform, `<TARGET>` can be `linux_x86_64`,
+    `rpi_armv7l`, or `aarch64_armv8-a`. In the `bin` folder, you can find the
+    example program `lce_minimal` and benchmark program `benchmark_model`.
+    In the `lib` folder, you can find the TensorFlow Lite static library
+    `libtensorflow-lite.a` which includes the LCE customs ops.
 
-When building for a 64-bit ARM architecture, replace `--rpi` with `--aarch64`.
 
-See [Building LCE with Make](#building-lce-with-make) for the location of
-the resulting build files. Copy the `benchmark_model` program to your ARM
-machine to run it.
+    !!! note
+        On some systems the compiler is incorrectly named `aarch64-unknown-linux-gnu-gcc`
+        while it should be named `aarch64-linux-gnu-gcc`. If building with the option
+        `--aarch64` results in errors then the following bash script can be used to
+        create symlinks that fix this naming issue.
+
+        ```bash
+        #!/usr/bin/env bash
+
+        cd /usr/bin
+        for unknownfile in aarch64-unknown-linux-gnu-*; do
+        	newfile="${unknownfile/-unknown-/-}"    
+        	echo "Creating symlink $newfile that points to $unknownfile"
+        	ln -s $unknownfile $newfile
+        done
+        ```
+
+=== "Cross-compiling with Make"
+
+    First clone the Larq Compute Engine repository and make sure the tensorflow
+    submodule is loaded:
+
+    ```bash
+    git submodule update --init
+    ```
+
+    To cross-compile LCE, you need to first install the compiler toolchain:
+
+    === "Linux (Debian based)"
+        ```bash
+        sudo apt-get update
+        sudo apt-get install crossbuild-essential-armhf
+        ```
+
+    === "Linux (Arch based)"
+        ```bash
+        sudo pacman -Syy
+        sudo pacman -S arm-linux-gnueabihf
+        ```
+
+    To build for 32-bit ARM architectures, run the following command from the LCE
+    root directory:
+
+    ```bash
+    larq_compute_engine/tflite/build_make/build_lce.sh --rpi
+    ```
+
+    When building for a 64-bit ARM architecture, replace `--rpi` with `--aarch64`.
+
+    The resulting compiled files will be stored in
+    `third_party/tensorflow/tensorflow/lite/tools/make/gen/<TARGET>` where,
+    depending on your target platform, `<TARGET>` can be `linux_x86_64`,
+    `rpi_armv7l`, or `aarch64_armv8-a`. In the `bin` folder, you can find the
+    example program `lce_minimal` and benchmark program `benchmark_model`.
+    In the `lib` folder, you can find the TensorFlow Lite static library
+    `libtensorflow-lite.a` which includes the LCE customs ops.
+
+    Copy the `benchmark_model` program to your ARM
+    machine to run it.


### PR DESCRIPTION
This PR splits the different compilation options of the ARM binaries in three different tabs to trim down the size of the build instructions.

Looking at this again, I am actually not 100% sure if this is a readability improvement: [rendered preview](https://docs-6hqhw27c7.vercel.app/compute-engine/build/arm/)

@Tombana what do you think?