### PR TITLE
Don't generate model summaries twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "install": "python3 -m pip install -r requirements.txt",
     "prebuild": "./download_lce_readme.sh && python3 generate_docs.py",
-    "build": "python3 -m mkdocs build -d public",
+    "build": "IGNORE_MODEL_SUMMARIES=1 python3 -m mkdocs build -d public && python3 -m mkdocs build -d public",
     "dev": "IGNORE_MODEL_SUMMARIES=1 python3 -m mkdocs serve"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "scripts": {
     "install": "python3 -m pip install -r requirements.txt",
     "prebuild": "./download_lce_readme.sh && python3 generate_docs.py",
-    "build:docs": "python3 -m mkdocs build -d public",
-    "build": "npm run build:docs && npm run build:docs",
+    "build": "python3 -m mkdocs build -d public",
     "dev": "IGNORE_MODEL_SUMMARIES=1 python3 -m mkdocs serve"
   }
 }


### PR DESCRIPTION
We currently need to build our docs twice to make sure the quantizer plots render correctly. However for the first build we can ignore the model summaries which should speedup the docs build slightly.