### PR TITLE
Switch from Binder to Google Colab for running our tutorials

### DIFF
--- a/docs/compute-engine/end_to_end.ipynb
+++ b/docs/compute-engine/end_to_end.ipynb
@@ -1,36 +1,17 @@
 {
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.2-final"
-  },
-  "orig_nbformat": 2,
-  "kernelspec": {
-   "name": "python38264bitvenvvenvc6a0c56cef40423dadad7c09f704025c",
-   "display_name": "Python 3.8.2 64-bit ('venv': venv)"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2,
  "cells": [
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# End to End Guide: Converting and Benchmarking a Model\n",
-    "<a href=\"https://mybinder.org/v2/gh/larq/docs/master?filepath=docs%2Fcompute-engine%2Fend_to_end.ipynb\"><button class=\"notebook-badge\">Run on Binder</button></a> <a href=\"https://github.com/larq/docs/blob/master/docs/larq/compute-engine/end_to_end.ipynb\"><button class=\"notebook-badge\">View on GitHub</button></a>\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/larq/docs/blob/master/docs/compute-engine/end_to_end.ipynb\"><button class=\"notebook-badge\">Run on Colab</button></a> <a href=\"https://github.com/larq/docs/blob/master/docs/larq/compute-engine/end_to_end.ipynb\"><button class=\"notebook-badge\">View on GitHub</button></a>\n",
     "\n",
     "These steps will walk you through deploying a BNN with LCE. The guide starts by downloading, converting and benchmarking a model from [Larq Zoo](/zoo/), and will then discuss the process for a custom model.\n",
     "\n",
-    "## 1. Picking a model from Larq Zoo\n",
+    "## Picking a model from Larq Zoo\n",
+    "\n",
     "This example uses the [QuickNet model](/zoo/api/sota/#quicknet) from the `sota` submodule of `larq-zoo`.\n",
     "First, install the Larq Ecosystem pip packages:\n"
    ]
@@ -43,7 +24,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install larq larq-zoo larq-compute-engine"
+    "pip install larq larq-zoo larq-compute-engine"
    ]
   },
   {
@@ -61,9 +42,85 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "+quicknet stats----------------------------------------------------------------------------------------------------+\n| Layer                   Input prec.                 Outputs  # 1-bit  # 32-bit   Memory  1-bit MACs  32-bit MACs |\n|                               (bit)                              x 1       x 1     (kB)                          |\n+------------------------------------------------------------------------------------------------------------------+\n| input_1                           -  ((None, 224, 224, 3),)        0         0        0           ?            ? |\n| conv2d                            -       (-1, 112, 112, 8)        0       216     0.84           0      2709504 |\n| depthwise_conv2d                  -        (-1, 56, 56, 64)        0       576     2.25           0      1806336 |\n| batch_normalization               -        (-1, 56, 56, 64)        0       128     0.50           0            0 |\n| quant_conv2d                      1        (-1, 56, 56, 64)    36864         0     4.50   115605504            0 |\n| batch_normalization_1             -        (-1, 56, 56, 64)        0       128     0.50           0            0 |\n| add                               -        (-1, 56, 56, 64)        0         0        0           ?            ? |\n| quant_conv2d_1                    1        (-1, 56, 56, 64)    36864         0     4.50   115605504            0 |\n| batch_normalization_2             -        (-1, 56, 56, 64)        0       128     0.50           0            0 |\n| add_1                             -        (-1, 56, 56, 64)        0         0        0           ?            ? |\n| max_pooling2d                     -        (-1, 28, 28, 64)        0         0        0           0            0 |\n| quant_conv2d_2                    1        (-1, 28, 28, 64)    36864         0     4.50    28901376            0 |\n| batch_normalization_3             -        (-1, 28, 28, 64)        0       128     0.50           0            0 |\n| batch_normalization_4             -        (-1, 28, 28, 64)        0       128     0.50           0            0 |\n| add_2                             -        (-1, 28, 28, 64)        0         0        0           ?            ? |\n| concatenate                       -       (-1, 28, 28, 128)        0         0        0           ?            ? |\n| quant_conv2d_3                    1       (-1, 28, 28, 128)   147456         0    18.00   115605504            0 |\n| batch_normalization_5             -       (-1, 28, 28, 128)        0       256     1.00           0            0 |\n| add_3                             -       (-1, 28, 28, 128)        0         0        0           ?            ? |\n| quant_conv2d_4                    1       (-1, 28, 28, 128)   147456         0    18.00   115605504            0 |\n| batch_normalization_6             -       (-1, 28, 28, 128)        0       256     1.00           0            0 |\n| add_4                             -       (-1, 28, 28, 128)        0         0        0           ?            ? |\n| max_pooling2d_1                   -       (-1, 14, 14, 128)        0         0        0           0            0 |\n| quant_conv2d_5                    1       (-1, 14, 14, 128)   147456         0    18.00    28901376            0 |\n| batch_normalization_7             -       (-1, 14, 14, 128)        0       256     1.00           0            0 |\n| batch_normalization_8             -       (-1, 14, 14, 128)        0       256     1.00           0            0 |\n| add_5                             -       (-1, 14, 14, 128)        0         0        0           ?            ? |\n| concatenate_1                     -       (-1, 14, 14, 256)        0         0        0           ?            ? |\n| quant_conv2d_6                    1       (-1, 14, 14, 256)   589824         0    72.00   115605504            0 |\n| batch_normalization_9             -       (-1, 14, 14, 256)        0       512     2.00           0            0 |\n| add_6                             -       (-1, 14, 14, 256)        0         0        0           ?            ? |\n| quant_conv2d_7                    1       (-1, 14, 14, 256)   589824         0    72.00   115605504            0 |\n| batch_normalization_10            -       (-1, 14, 14, 256)        0       512     2.00           0            0 |\n| add_7                             -       (-1, 14, 14, 256)        0         0        0           ?            ? |\n| quant_conv2d_8                    1       (-1, 14, 14, 256)   589824         0    72.00   115605504            0 |\n| batch_normalization_11            -       (-1, 14, 14, 256)        0       512     2.00           0            0 |\n| add_8                             -       (-1, 14, 14, 256)        0         0        0           ?            ? |\n| max_pooling2d_2                   -         (-1, 7, 7, 256)        0         0        0           0            0 |\n| quant_conv2d_9                    1         (-1, 7, 7, 256)   589824         0    72.00    28901376            0 |\n| batch_normalization_12            -         (-1, 7, 7, 256)        0       512     2.00           0            0 |\n| batch_normalization_13            -         (-1, 7, 7, 256)        0       512     2.00           0            0 |\n| add_9                             -         (-1, 7, 7, 256)        0         0        0           ?            ? |\n| concatenate_2                     -         (-1, 7, 7, 512)        0         0        0           ?            ? |\n| quant_conv2d_10                   1         (-1, 7, 7, 512)  2359296         0   288.00   115605504            0 |\n| batch_normalization_14            -         (-1, 7, 7, 512)        0      1024     4.00           0            0 |\n| add_10                            -         (-1, 7, 7, 512)        0         0        0           ?            ? |\n| quant_conv2d_11                   1         (-1, 7, 7, 512)  2359296         0   288.00   115605504            0 |\n| batch_normalization_15            -         (-1, 7, 7, 512)        0      1024     4.00           0            0 |\n| add_11                            -         (-1, 7, 7, 512)        0         0        0           ?            ? |\n| quant_conv2d_12                   1         (-1, 7, 7, 512)  2359296         0   288.00   115605504            0 |\n| batch_normalization_16            -         (-1, 7, 7, 512)        0      1024     4.00           0            0 |\n| add_12                            -         (-1, 7, 7, 512)        0         0        0           ?            ? |\n| activation                        -         (-1, 7, 7, 512)        0         0        0           ?            ? |\n| average_pooling2d                 -         (-1, 1, 1, 512)        0         0        0           0            0 |\n| flatten                           -               (-1, 512)        0         0        0           0            0 |\n| dense                             -              (-1, 1000)        0    513000  2003.91           0       512000 |\n| activation_1                      -              (-1, 1000)        0         0        0           ?            ? |\n+------------------------------------------------------------------------------------------------------------------+\n| Total                                                        9990144    521088  3255.00  1242759168      5027840 |\n+------------------------------------------------------------------------------------------------------------------+\n+quicknet summary-----------------------------+\n| Total params                      10.5 M    |\n| Trainable params                  10.5 M    |\n| Non-trainable params              7.3 k     |\n| Model size                        3.18 MiB  |\n| Model size (8-bit FP weights)     1.69 MiB  |\n| Float-32 Equivalent               40.10 MiB |\n| Compression Ratio of Memory       0.08      |\n| Number of MACs                    1.25 B    |\n| Ratio of MACs that are binarized  0.9960    |\n+---------------------------------------------+\n"
+     "output_type": "stream",
+     "text": [
+      "+quicknet stats----------------------------------------------------------------------------------------------------+\n",
+      "| Layer                   Input prec.                 Outputs  # 1-bit  # 32-bit   Memory  1-bit MACs  32-bit MACs |\n",
+      "|                               (bit)                              x 1       x 1     (kB)                          |\n",
+      "+------------------------------------------------------------------------------------------------------------------+\n",
+      "| input_1                           -  ((None, 224, 224, 3),)        0         0        0           ?            ? |\n",
+      "| conv2d                            -       (-1, 112, 112, 8)        0       216     0.84           0      2709504 |\n",
+      "| depthwise_conv2d                  -        (-1, 56, 56, 64)        0       576     2.25           0      1806336 |\n",
+      "| batch_normalization               -        (-1, 56, 56, 64)        0       128     0.50           0            0 |\n",
+      "| quant_conv2d                      1        (-1, 56, 56, 64)    36864         0     4.50   115605504            0 |\n",
+      "| batch_normalization_1             -        (-1, 56, 56, 64)        0       128     0.50           0            0 |\n",
+      "| add                               -        (-1, 56, 56, 64)        0         0        0           ?            ? |\n",
+      "| quant_conv2d_1                    1        (-1, 56, 56, 64)    36864         0     4.50   115605504            0 |\n",
+      "| batch_normalization_2             -        (-1, 56, 56, 64)        0       128     0.50           0            0 |\n",
+      "| add_1                             -        (-1, 56, 56, 64)        0         0        0           ?            ? |\n",
+      "| max_pooling2d                     -        (-1, 28, 28, 64)        0         0        0           0            0 |\n",
+      "| quant_conv2d_2                    1        (-1, 28, 28, 64)    36864         0     4.50    28901376            0 |\n",
+      "| batch_normalization_3             -        (-1, 28, 28, 64)        0       128     0.50           0            0 |\n",
+      "| batch_normalization_4             -        (-1, 28, 28, 64)        0       128     0.50           0            0 |\n",
+      "| add_2                             -        (-1, 28, 28, 64)        0         0        0           ?            ? |\n",
+      "| concatenate                       -       (-1, 28, 28, 128)        0         0        0           ?            ? |\n",
+      "| quant_conv2d_3                    1       (-1, 28, 28, 128)   147456         0    18.00   115605504            0 |\n",
+      "| batch_normalization_5             -       (-1, 28, 28, 128)        0       256     1.00           0            0 |\n",
+      "| add_3                             -       (-1, 28, 28, 128)        0         0        0           ?            ? |\n",
+      "| quant_conv2d_4                    1       (-1, 28, 28, 128)   147456         0    18.00   115605504            0 |\n",
+      "| batch_normalization_6             -       (-1, 28, 28, 128)        0       256     1.00           0            0 |\n",
+      "| add_4                             -       (-1, 28, 28, 128)        0         0        0           ?            ? |\n",
+      "| max_pooling2d_1                   -       (-1, 14, 14, 128)        0         0        0           0            0 |\n",
+      "| quant_conv2d_5                    1       (-1, 14, 14, 128)   147456         0    18.00    28901376            0 |\n",
+      "| batch_normalization_7             -       (-1, 14, 14, 128)        0       256     1.00           0            0 |\n",
+      "| batch_normalization_8             -       (-1, 14, 14, 128)        0       256     1.00           0            0 |\n",
+      "| add_5                             -       (-1, 14, 14, 128)        0         0        0           ?            ? |\n",
+      "| concatenate_1                     -       (-1, 14, 14, 256)        0         0        0           ?            ? |\n",
+      "| quant_conv2d_6                    1       (-1, 14, 14, 256)   589824         0    72.00   115605504            0 |\n",
+      "| batch_normalization_9             -       (-1, 14, 14, 256)        0       512     2.00           0            0 |\n",
+      "| add_6                             -       (-1, 14, 14, 256)        0         0        0           ?            ? |\n",
+      "| quant_conv2d_7                    1       (-1, 14, 14, 256)   589824         0    72.00   115605504            0 |\n",
+      "| batch_normalization_10            -       (-1, 14, 14, 256)        0       512     2.00           0            0 |\n",
+      "| add_7                             -       (-1, 14, 14, 256)        0         0        0           ?            ? |\n",
+      "| quant_conv2d_8                    1       (-1, 14, 14, 256)   589824         0    72.00   115605504            0 |\n",
+      "| batch_normalization_11            -       (-1, 14, 14, 256)        0       512     2.00           0            0 |\n",
+      "| add_8                             -       (-1, 14, 14, 256)        0         0        0           ?            ? |\n",
+      "| max_pooling2d_2                   -         (-1, 7, 7, 256)        0         0        0           0            0 |\n",
+      "| quant_conv2d_9                    1         (-1, 7, 7, 256)   589824         0    72.00    28901376            0 |\n",
+      "| batch_normalization_12            -         (-1, 7, 7, 256)        0       512     2.00           0            0 |\n",
+      "| batch_normalization_13            -         (-1, 7, 7, 256)        0       512     2.00           0            0 |\n",
+      "| add_9                             -         (-1, 7, 7, 256)        0         0        0           ?            ? |\n",
+      "| concatenate_2                     -         (-1, 7, 7, 512)        0         0        0           ?            ? |\n",
+      "| quant_conv2d_10                   1         (-1, 7, 7, 512)  2359296         0   288.00   115605504            0 |\n",
+      "| batch_normalization_14            -         (-1, 7, 7, 512)        0      1024     4.00           0            0 |\n",
+      "| add_10                            -         (-1, 7, 7, 512)        0         0        0           ?            ? |\n",
+      "| quant_conv2d_11                   1         (-1, 7, 7, 512)  2359296         0   288.00   115605504            0 |\n",
+      "| batch_normalization_15            -         (-1, 7, 7, 512)        0      1024     4.00           0            0 |\n",
+      "| add_11                            -         (-1, 7, 7, 512)        0         0        0           ?            ? |\n",
+      "| quant_conv2d_12                   1         (-1, 7, 7, 512)  2359296         0   288.00   115605504            0 |\n",
+      "| batch_normalization_16            -         (-1, 7, 7, 512)        0      1024     4.00           0            0 |\n",
+      "| add_12                            -         (-1, 7, 7, 512)        0         0        0           ?            ? |\n",
+      "| activation                        -         (-1, 7, 7, 512)        0         0        0           ?            ? |\n",
+      "| average_pooling2d                 -         (-1, 1, 1, 512)        0         0        0           0            0 |\n",
+      "| flatten                           -               (-1, 512)        0         0        0           0            0 |\n",
+      "| dense                             -              (-1, 1000)        0    513000  2003.91           0       512000 |\n",
+      "| activation_1                      -              (-1, 1000)        0         0        0           ?            ? |\n",
+      "+------------------------------------------------------------------------------------------------------------------+\n",
+      "| Total                                                        9990144    521088  3255.00  1242759168      5027840 |\n",
+      "+------------------------------------------------------------------------------------------------------------------+\n",
+      "+quicknet summary-----------------------------+\n",
+      "| Total params                      10.5 M    |\n",
+      "| Trainable params                  10.5 M    |\n",
+      "| Non-trainable params              7.3 k     |\n",
+      "| Model size                        3.18 MiB  |\n",
+      "| Model size (8-bit FP weights)     1.69 MiB  |\n",
+      "| Float-32 Equivalent               40.10 MiB |\n",
+      "| Compression Ratio of Memory       0.08      |\n",
+      "| Number of MACs                    1.25 B    |\n",
+      "| Ratio of MACs that are binarized  0.9960    |\n",
+      "+---------------------------------------------+\n"
+     ]
     }
    ],
    "source": [
@@ -89,7 +146,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Converting the model\n",
+    "## Converting the model\n",
+    "\n",
     "Larq Compute Engine is built on top of TensorFlow Lite, and therefore uses the [TensorFlow Lite FlatBuffer format](https://google.github.io/flatbuffers/) to convert and serialize Larq models for inference. We provide our own [LCE Model Converter](/compute-engine/api/converter/) to convert models from Keras to flatbuffers, containing additional optimization passes that increase the execution speed of Larq models on the supported target platforms. \n",
     "\n",
     "Using this converter is very simple, and can be done by adding the following code to the python script above:"
@@ -118,7 +176,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 3. Benchmarking\n",
+    "## Benchmarking\n",
+    "\n",
     "This part of the guide assumes that you'll want to benchmark on an 64-bit ARM based system such as a Raspberry Pi. For more detailed instructions on benchmarking and for benchmarking on Android phones, see the [Benchmarking guide](/compute-engine/benchmark).\n",
     "\n",
     "On ARM, benchmarking is as simple as downloading the pre-built benchmarking binary from the [latest release](https://github.com/larq/compute-engine/releases/latest) to the target device and running it with the converted model:\n",
@@ -129,13 +188,33 @@
   },
   {
    "cell_type": "code",
-   "metadata": {},
    "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "STARTING!\nDuplicate flags: num_threads\nMin num runs: [50]\nMin runs duration (seconds): [1]\nMax runs duration (seconds): [150]\nInter-run delay (seconds): [-1]\nNum threads: [1]\n...\n...\nLoaded model quicknet.tflite\nThe input model file size (MB): 3.3512\nInitialized session in 1.471ms.\nRunning benchmark for at least 1 iterations and at least 0.5 seconds but terminate if exceeding 150 seconds.\ncount=16 first=41707 curr=31870 min=31722 max=41707 avg=32491.4 std=2395\n\nRunning benchmark for at least 50 iterations and at least 1 seconds but terminate if exceeding 150 seconds.\ncount=50 first=31929 curr=31278 min=31138 max=31929 avg=31420.6 std=260\n\nInference timings in us: Init: 1471, First inference: 41707, Warmup (avg): 32491.4, Inference (avg): 31420.6"
+     "output_type": "stream",
+     "text": [
+      "STARTING!\n",
+      "Duplicate flags: num_threads\n",
+      "Min num runs: [50]\n",
+      "Min runs duration (seconds): [1]\n",
+      "Max runs duration (seconds): [150]\n",
+      "Inter-run delay (seconds): [-1]\n",
+      "Num threads: [1]\n",
+      "...\n",
+      "...\n",
+      "Loaded model quicknet.tflite\n",
+      "The input model file size (MB): 3.3512\n",
+      "Initialized session in 1.471ms.\n",
+      "Running benchmark for at least 1 iterations and at least 0.5 seconds but terminate if exceeding 150 seconds.\n",
+      "count=16 first=41707 curr=31870 min=31722 max=41707 avg=32491.4 std=2395\n",
+      "\n",
+      "Running benchmark for at least 50 iterations and at least 1 seconds but terminate if exceeding 150 seconds.\n",
+      "count=50 first=31929 curr=31278 min=31138 max=31929 avg=31420.6 std=260\n",
+      "\n",
+      "Inference timings in us: Init: 1471, First inference: 41707, Warmup (avg): 32491.4, Inference (avg): 31420.6"
+     ]
     }
    ],
    "source": [
@@ -157,7 +236,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 4. Create your own Larq model\n",
+    "## Create your own Larq model\n",
+    "\n",
     "Instead of using one of our models, you probably want to benchmark a custom model that you trained yourself. For more information on creating and training a BNN with Larq, see our [Larq User Guides](/). For best practices on optimizing Larq models for LCE, also see our [Model Optimization Guide](/compute-engine/model_optimization_guide).\n",
     "\n",
     "The code below defines a simple BNN model that takes a 32x32 input image and classifies it into one of 10 classes."
@@ -171,9 +251,38 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "+sequential_4 stats---------------------------------------------------------------------------------------------+\n| Layer                       Input prec.           Outputs  # 1-bit  # 32-bit  Memory  1-bit MACs  32-bit MACs |\n|                                   (bit)                        x 1       x 1    (kB)                          |\n+---------------------------------------------------------------------------------------------------------------+\n| conv2d_5                              -  (-1, 11, 11, 32)        0      2432    9.50           0       290400 |\n| batch_normalization_29                -  (-1, 11, 11, 32)        0        64    0.25           0            0 |\n| quant_conv2d_21                       1    (-1, 6, 6, 32)     9216         0    1.12      331776            0 |\n| batch_normalization_30                -    (-1, 6, 6, 32)        0        64    0.25           0            0 |\n| activation_10                         -    (-1, 6, 6, 32)        0         0       0           ?            ? |\n| quant_conv2d_22                       1    (-1, 3, 3, 64)    18432         0    2.25      165888            0 |\n| batch_normalization_31                -    (-1, 3, 3, 64)        0       128    0.50           0            0 |\n| activation_11                         -    (-1, 3, 3, 64)        0         0       0           ?            ? |\n| global_average_pooling2d_4            -          (-1, 64)        0         0       0           ?            ? |\n| dense_5                               -          (-1, 10)        0       650    2.54           0          640 |\n+---------------------------------------------------------------------------------------------------------------+\n| Total                                                        27648      3338   16.41      497664       291040 |\n+---------------------------------------------------------------------------------------------------------------+\n+sequential_4 summary--------------------------+\n| Total params                      31 k       |\n| Trainable params                  30.7 k     |\n| Non-trainable params              256        |\n| Model size                        16.41 KiB  |\n| Model size (8-bit FP weights)     6.63 KiB   |\n| Float-32 Equivalent               121.04 KiB |\n| Compression Ratio of Memory       0.14       |\n| Number of MACs                    789 k      |\n| Ratio of MACs that are binarized  0.6310     |\n+----------------------------------------------+\n"
+     "output_type": "stream",
+     "text": [
+      "+sequential_4 stats---------------------------------------------------------------------------------------------+\n",
+      "| Layer                       Input prec.           Outputs  # 1-bit  # 32-bit  Memory  1-bit MACs  32-bit MACs |\n",
+      "|                                   (bit)                        x 1       x 1    (kB)                          |\n",
+      "+---------------------------------------------------------------------------------------------------------------+\n",
+      "| conv2d_5                              -  (-1, 11, 11, 32)        0      2432    9.50           0       290400 |\n",
+      "| batch_normalization_29                -  (-1, 11, 11, 32)        0        64    0.25           0            0 |\n",
+      "| quant_conv2d_21                       1    (-1, 6, 6, 32)     9216         0    1.12      331776            0 |\n",
+      "| batch_normalization_30                -    (-1, 6, 6, 32)        0        64    0.25           0            0 |\n",
+      "| activation_10                         -    (-1, 6, 6, 32)        0         0       0           ?            ? |\n",
+      "| quant_conv2d_22                       1    (-1, 3, 3, 64)    18432         0    2.25      165888            0 |\n",
+      "| batch_normalization_31                -    (-1, 3, 3, 64)        0       128    0.50           0            0 |\n",
+      "| activation_11                         -    (-1, 3, 3, 64)        0         0       0           ?            ? |\n",
+      "| global_average_pooling2d_4            -          (-1, 64)        0         0       0           ?            ? |\n",
+      "| dense_5                               -          (-1, 10)        0       650    2.54           0          640 |\n",
+      "+---------------------------------------------------------------------------------------------------------------+\n",
+      "| Total                                                        27648      3338   16.41      497664       291040 |\n",
+      "+---------------------------------------------------------------------------------------------------------------+\n",
+      "+sequential_4 summary--------------------------+\n",
+      "| Total params                      31 k       |\n",
+      "| Trainable params                  30.7 k     |\n",
+      "| Non-trainable params              256        |\n",
+      "| Model size                        16.41 KiB  |\n",
+      "| Model size (8-bit FP weights)     6.63 KiB   |\n",
+      "| Float-32 Equivalent               121.04 KiB |\n",
+      "| Compression Ratio of Memory       0.14       |\n",
+      "| Number of MACs                    789 k      |\n",
+      "| Ratio of MACs that are binarized  0.6310     |\n",
+      "+----------------------------------------------+\n"
+     ]
     }
    ],
    "source": [
@@ -225,8 +334,7 @@
     "# Convert our Keras model to a TFLite flatbuffer file\n",
     "with open(\"custom_model.tflite\", \"wb\") as flatbuffer_file:\n",
     "    flatbuffer_bytes = lce.convert_keras_model(model)\n",
-    "    flatbuffer_file.write(flatbuffer_bytes)\n",
-    "\n"
+    "    flatbuffer_file.write(flatbuffer_bytes)"
    ]
   },
   {
@@ -315,9 +423,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 5. Next Steps\n",
+    "## Next Steps\n",
+    "\n",
     "Now that you've succesfully created and benchmarked your own BNN, you probably want to use it for a custom application. For information on using the Larq Compute Engine for inference, check out our [C++](/compute-engine/inference) and [Android](/compute-engine/quickstart_android) inference guides."
    ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/docs/larq/tutorials/binarynet_cifar10.ipynb
+++ b/docs/larq/tutorials/binarynet_cifar10.ipynb
@@ -1,545 +1,563 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# BinaryNet on CIFAR10\n",
-        "\n",
-        "<a href=\"https://mybinder.org/v2/gh/larq/docs/master?filepath=docs%2Flarq%2Ftutorials%2Fbinarynet_cifar10.ipynb\"><button class=\"notebook-badge\">Run on Binder</button></a> <a href=\"https://github.com/larq/docs/blob/master/docs/larq/tutorials/binarynet_cifar10.ipynb\"><button class=\"notebook-badge\">View on GitHub</button></a>\n",
-        "\n",
-        "In this example we demonstrate how to use Larq to build and train BinaryNet on the CIFAR10 dataset to achieve a validation accuracy approximately 83% on laptop hardware.\n",
-        "On a Nvidia GTX 1050 Ti Max-Q it takes approximately 200 minutes to train. For simplicity, compared to the original papers [BinaryConnect: Training Deep Neural Networks with binary weights during propagations](https://arxiv.org/abs/1511.00363), and [Binarized Neural Networks: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1](https://arxiv.org/abs/1602.02830), we do not impliment learning rate scaling, or image whitening."
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import tensorflow as tf\n",
-        "import larq as lq\n",
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt"
-      ],
-      "outputs": [],
-      "execution_count": 1,
-      "metadata": {}
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Import CIFAR10 Dataset\n",
-        "\n",
-        "We download and normalize the CIFAR10 dataset."
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "num_classes = 10\n",
-        "\n",
-        "(train_images, train_labels), (test_images, test_labels) = tf.keras.datasets.cifar10.load_data()\n",
-        "\n",
-        "train_images = train_images.reshape((50000, 32, 32, 3)).astype(\"float32\")\n",
-        "test_images = test_images.reshape((10000, 32, 32, 3)).astype(\"float32\")\n",
-        "\n",
-        "# Normalize pixel values to be between -1 and 1\n",
-        "train_images, test_images = train_images / 127.5 - 1, test_images / 127.5 - 1\n",
-        "\n",
-        "train_labels = tf.keras.utils.to_categorical(train_labels, num_classes)\n",
-        "test_labels = tf.keras.utils.to_categorical(test_labels, num_classes)"
-      ],
-      "outputs": [],
-      "execution_count": 2,
-      "metadata": {}
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Build BinaryNet\n",
-        "\n",
-        "Here we build the BinaryNet model layer by layer using the [Keras Sequential API](https://www.tensorflow.org/guide/keras)."
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "# All quantized layers except the first will use the same options\n",
-        "kwargs = dict(input_quantizer=\"ste_sign\",\n",
-        "              kernel_quantizer=\"ste_sign\",\n",
-        "              kernel_constraint=\"weight_clip\",\n",
-        "              use_bias=False)\n",
-        "\n",
-        "model = tf.keras.models.Sequential([\n",
-        "    # In the first layer we only quantize the weights and not the input\n",
-        "    lq.layers.QuantConv2D(128, 3,\n",
-        "                          kernel_quantizer=\"ste_sign\",\n",
-        "                          kernel_constraint=\"weight_clip\",\n",
-        "                          use_bias=False,\n",
-        "                          input_shape=(32, 32, 3)),\n",
-        "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
-        "\n",
-        "    lq.layers.QuantConv2D(128, 3, padding=\"same\", **kwargs),\n",
-        "    tf.keras.layers.MaxPool2D(pool_size=(2, 2), strides=(2, 2)),\n",
-        "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
-        "\n",
-        "    lq.layers.QuantConv2D(256, 3, padding=\"same\", **kwargs),\n",
-        "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
-        "\n",
-        "    lq.layers.QuantConv2D(256, 3, padding=\"same\", **kwargs),\n",
-        "    tf.keras.layers.MaxPool2D(pool_size=(2, 2), strides=(2, 2)),\n",
-        "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
-        "\n",
-        "    lq.layers.QuantConv2D(512, 3, padding=\"same\", **kwargs),\n",
-        "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
-        "\n",
-        "    lq.layers.QuantConv2D(512, 3, padding=\"same\", **kwargs),\n",
-        "    tf.keras.layers.MaxPool2D(pool_size=(2, 2), strides=(2, 2)),\n",
-        "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
-        "    tf.keras.layers.Flatten(),\n",
-        "\n",
-        "    lq.layers.QuantDense(1024, **kwargs),\n",
-        "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
-        "\n",
-        "    lq.layers.QuantDense(1024, **kwargs),\n",
-        "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
-        "\n",
-        "    lq.layers.QuantDense(10, **kwargs),\n",
-        "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
-        "    tf.keras.layers.Activation(\"softmax\")\n",
-        "])"
-      ],
-      "outputs": [],
-      "execution_count": 4,
-      "metadata": {}
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "One can output a summary of the model:"
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "lq.models.summary(model)"
-      ],
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "+sequential_1 stats-------------------------------------------------------------------+\n",
-            "| Layer                   Input prec.            Outputs   # 1-bit  # 32-bit   Memory |\n",
-            "|                               (bit)                                            (kB) |\n",
-            "+-------------------------------------------------------------------------------------+\n",
-            "| quant_conv2d_6                    -  (-1, 30, 30, 128)      3456         0     0.42 |\n",
-            "| batch_normalization_9             -  (-1, 30, 30, 128)         0       384     1.50 |\n",
-            "| quant_conv2d_7                    1  (-1, 30, 30, 128)    147456         0    18.00 |\n",
-            "| max_pooling2d_3                   -  (-1, 15, 15, 128)         0         0     0.00 |\n",
-            "| batch_normalization_10            -  (-1, 15, 15, 128)         0       384     1.50 |\n",
-            "| quant_conv2d_8                    1  (-1, 15, 15, 256)    294912         0    36.00 |\n",
-            "| batch_normalization_11            -  (-1, 15, 15, 256)         0       768     3.00 |\n",
-            "| quant_conv2d_9                    1  (-1, 15, 15, 256)    589824         0    72.00 |\n",
-            "| max_pooling2d_4                   -    (-1, 7, 7, 256)         0         0     0.00 |\n",
-            "| batch_normalization_12            -    (-1, 7, 7, 256)         0       768     3.00 |\n",
-            "| quant_conv2d_10                   1    (-1, 7, 7, 512)   1179648         0   144.00 |\n",
-            "| batch_normalization_13            -    (-1, 7, 7, 512)         0      1536     6.00 |\n",
-            "| quant_conv2d_11                   1    (-1, 7, 7, 512)   2359296         0   288.00 |\n",
-            "| max_pooling2d_5                   -    (-1, 3, 3, 512)         0         0     0.00 |\n",
-            "| batch_normalization_14            -    (-1, 3, 3, 512)         0      1536     6.00 |\n",
-            "| flatten_1                         -         (-1, 4608)         0         0     0.00 |\n",
-            "| quant_dense_3                     1         (-1, 1024)   4718592         0   576.00 |\n",
-            "| batch_normalization_15            -         (-1, 1024)         0      3072    12.00 |\n",
-            "| quant_dense_4                     1         (-1, 1024)   1048576         0   128.00 |\n",
-            "| batch_normalization_16            -         (-1, 1024)         0      3072    12.00 |\n",
-            "| quant_dense_5                     1           (-1, 10)     10240         0     1.25 |\n",
-            "| batch_normalization_17            -           (-1, 10)         0        30     0.12 |\n",
-            "| activation_1                      -           (-1, 10)         0         0     0.00 |\n",
-            "+-------------------------------------------------------------------------------------+\n",
-            "| Total                                                   10352000     11550  1308.79 |\n",
-            "+-------------------------------------------------------------------------------------+\n",
-            "+sequential_1 summary-------------+\n",
-            "| Total params           10363550 |\n",
-            "| Trainable params       10355850 |\n",
-            "| Non-trainable params   7700     |\n",
-            "| Float-32 Equivalent    39.53 MB |\n",
-            "| Compression of Memory  30.93    |\n",
-            "+---------------------------------+\n"
-          ]
-        }
-      ],
-      "execution_count": 5,
-      "metadata": {}
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Model Training\n",
-        "\n",
-        "Compile the model and train the model"
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "model.compile(\n",
-        "    tf.keras.optimizers.Adam(lr=0.01,decay=0.0001),\n",
-        "    loss=\"categorical_crossentropy\",\n",
-        "    metrics=[\"accuracy\"],\n",
-        ")"
-      ],
-      "outputs": [],
-      "execution_count": 6,
-      "metadata": {
-        "scrolled": true
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "trained_model = model.fit(\n",
-        "    train_images, \n",
-        "    train_labels,\n",
-        "    batch_size=50, \n",
-        "    epochs=100,\n",
-        "    validation_data=(test_images, test_labels),\n",
-        "    shuffle=True\n",
-        ")"
-      ],
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Train on 50000 samples, validate on 10000 samples\n",
-            "Epoch 1/100\n",
-            "50000/50000 [==============================] - 131s 3ms/step - loss: 1.5733 - acc: 0.4533 - val_loss: 1.6368 - val_acc: 0.4244\n",
-            "Epoch 2/100\n",
-            "50000/50000 [==============================] - 125s 3ms/step - loss: 1.1485 - acc: 0.6387 - val_loss: 1.8497 - val_acc: 0.3764\n",
-            "Epoch 3/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.9641 - acc: 0.7207 - val_loss: 1.5696 - val_acc: 0.4794\n",
-            "Epoch 4/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.8452 - acc: 0.7728 - val_loss: 1.5765 - val_acc: 0.4669\n",
-            "Epoch 5/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.7553 - acc: 0.8114 - val_loss: 1.0653 - val_acc: 0.6928\n",
-            "Epoch 6/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.6841 - acc: 0.8447 - val_loss: 1.0944 - val_acc: 0.6880\n",
-            "Epoch 7/100\n",
-            "50000/50000 [==============================] - 125s 3ms/step - loss: 0.6356 - acc: 0.8685 - val_loss: 0.9909 - val_acc: 0.7317\n",
-            "Epoch 8/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.5907 - acc: 0.8910 - val_loss: 0.9453 - val_acc: 0.7446\n",
-            "Epoch 9/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.5610 - acc: 0.9043 - val_loss: 0.9441 - val_acc: 0.7460\n",
-            "Epoch 10/100\n",
-            "50000/50000 [==============================] - 125s 3ms/step - loss: 0.5295 - acc: 0.9201 - val_loss: 0.8892 - val_acc: 0.7679\n",
-            "Epoch 11/100\n",
-            "50000/50000 [==============================] - 125s 2ms/step - loss: 0.5100 - acc: 0.9309 - val_loss: 0.8808 - val_acc: 0.7818\n",
-            "Epoch 12/100\n",
-            "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4926 - acc: 0.9397 - val_loss: 0.8404 - val_acc: 0.7894\n",
-            "Epoch 13/100\n",
-            "50000/50000 [==============================] - 125s 2ms/step - loss: 0.4807 - acc: 0.9470 - val_loss: 0.8600 - val_acc: 0.7928\n",
-            "Epoch 14/100\n",
-            "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4661 - acc: 0.9529 - val_loss: 0.9046 - val_acc: 0.7732\n",
-            "Epoch 15/100\n",
-            "50000/50000 [==============================] - 125s 3ms/step - loss: 0.4588 - acc: 0.9571 - val_loss: 0.8505 - val_acc: 0.7965\n",
-            "Epoch 16/100\n",
-            "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4558 - acc: 0.9593 - val_loss: 0.8748 - val_acc: 0.7859\n",
-            "Epoch 17/100\n",
-            "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4434 - acc: 0.9649 - val_loss: 0.9109 - val_acc: 0.7656\n",
-            "Epoch 18/100\n",
-            "50000/50000 [==============================] - 125s 2ms/step - loss: 0.4449 - acc: 0.9643 - val_loss: 0.8532 - val_acc: 0.7971\n",
-            "Epoch 19/100\n",
-            "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4349 - acc: 0.9701 - val_loss: 0.8677 - val_acc: 0.7951\n",
-            "Epoch 20/100\n",
-            "50000/50000 [==============================] - 125s 2ms/step - loss: 0.4351 - acc: 0.9698 - val_loss: 0.9145 - val_acc: 0.7740\n",
-            "Epoch 21/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4268 - acc: 0.9740 - val_loss: 0.8308 - val_acc: 0.8065\n",
-            "Epoch 22/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4243 - acc: 0.9741 - val_loss: 0.8229 - val_acc: 0.8075\n",
-            "Epoch 23/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4201 - acc: 0.9764 - val_loss: 0.8411 - val_acc: 0.8062\n",
-            "Epoch 24/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.4190 - acc: 0.9769 - val_loss: 0.8649 - val_acc: 0.7951\n",
-            "Epoch 25/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4139 - acc: 0.9787 - val_loss: 0.8257 - val_acc: 0.8071\n",
-            "Epoch 26/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4154 - acc: 0.9779 - val_loss: 0.8041 - val_acc: 0.8205\n",
-            "Epoch 27/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4128 - acc: 0.9798 - val_loss: 0.8296 - val_acc: 0.8115\n",
-            "Epoch 28/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.4121 - acc: 0.9798 - val_loss: 0.8241 - val_acc: 0.8074\n",
-            "Epoch 29/100\n",
-            "50000/50000 [==============================] - 125s 2ms/step - loss: 0.4093 - acc: 0.9807 - val_loss: 0.8575 - val_acc: 0.7913\n",
-            "Epoch 30/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.4048 - acc: 0.9826 - val_loss: 0.8118 - val_acc: 0.8166\n",
-            "Epoch 31/100\n",
-            "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4041 - acc: 0.9837 - val_loss: 0.8375 - val_acc: 0.8082\n",
-            "Epoch 32/100\n",
-            "50000/50000 [==============================] - 125s 2ms/step - loss: 0.4045 - acc: 0.9831 - val_loss: 0.8604 - val_acc: 0.8091\n",
-            "Epoch 33/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4047 - acc: 0.9823 - val_loss: 0.8797 - val_acc: 0.7931\n",
-            "Epoch 34/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.4023 - acc: 0.9842 - val_loss: 0.8694 - val_acc: 0.8020\n",
-            "Epoch 35/100\n",
-            "50000/50000 [==============================] - 125s 3ms/step - loss: 0.3995 - acc: 0.9858 - val_loss: 0.8161 - val_acc: 0.8186\n",
-            "Epoch 36/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3976 - acc: 0.9859 - val_loss: 0.8495 - val_acc: 0.7988\n",
-            "Epoch 37/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4021 - acc: 0.9847 - val_loss: 0.8542 - val_acc: 0.8062\n",
-            "Epoch 38/100\n",
-            "50000/50000 [==============================] - 125s 2ms/step - loss: 0.3939 - acc: 0.9869 - val_loss: 0.8347 - val_acc: 0.8122\n",
-            "Epoch 39/100\n",
-            "50000/50000 [==============================] - 125s 2ms/step - loss: 0.3955 - acc: 0.9856 - val_loss: 0.8521 - val_acc: 0.7993\n",
-            "Epoch 40/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3907 - acc: 0.9885 - val_loss: 0.9023 - val_acc: 0.7992\n",
-            "Epoch 41/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3911 - acc: 0.9873 - val_loss: 0.8597 - val_acc: 0.8010\n",
-            "Epoch 42/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3917 - acc: 0.9885 - val_loss: 0.8968 - val_acc: 0.7936\n",
-            "Epoch 43/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3931 - acc: 0.9874 - val_loss: 0.8318 - val_acc: 0.8169\n",
-            "Epoch 44/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3897 - acc: 0.9893 - val_loss: 0.8811 - val_acc: 0.7988\n",
-            "Epoch 45/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3876 - acc: 0.9888 - val_loss: 0.8453 - val_acc: 0.8094\n",
-            "Epoch 46/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3876 - acc: 0.9889 - val_loss: 0.8195 - val_acc: 0.8179\n",
-            "Epoch 47/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3891 - acc: 0.9890 - val_loss: 0.8373 - val_acc: 0.8137\n",
-            "Epoch 48/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3902 - acc: 0.9888 - val_loss: 0.8457 - val_acc: 0.8120\n",
-            "Epoch 49/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3864 - acc: 0.9903 - val_loss: 0.9012 - val_acc: 0.7907\n",
-            "Epoch 50/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3859 - acc: 0.9903 - val_loss: 0.8291 - val_acc: 0.8053\n",
-            "Epoch 51/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3830 - acc: 0.9915 - val_loss: 0.8494 - val_acc: 0.8139\n",
-            "Epoch 52/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3828 - acc: 0.9907 - val_loss: 0.8447 - val_acc: 0.8135\n",
-            "Epoch 53/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3823 - acc: 0.9910 - val_loss: 0.8539 - val_acc: 0.8120\n",
-            "Epoch 54/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3832 - acc: 0.9905 - val_loss: 0.8592 - val_acc: 0.8098\n",
-            "Epoch 55/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3823 - acc: 0.9908 - val_loss: 0.8585 - val_acc: 0.8087\n",
-            "Epoch 56/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3817 - acc: 0.9911 - val_loss: 0.8840 - val_acc: 0.7889\n",
-            "Epoch 57/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3827 - acc: 0.9914 - val_loss: 0.8205 - val_acc: 0.8250\n",
-            "Epoch 58/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3818 - acc: 0.9912 - val_loss: 0.8571 - val_acc: 0.8051\n",
-            "Epoch 59/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3811 - acc: 0.9919 - val_loss: 0.8155 - val_acc: 0.8254\n",
-            "Epoch 60/100\n",
-            "50000/50000 [==============================] - 125s 3ms/step - loss: 0.3803 - acc: 0.9919 - val_loss: 0.8617 - val_acc: 0.8040\n",
-            "Epoch 61/100\n",
-            "50000/50000 [==============================] - 125s 2ms/step - loss: 0.3793 - acc: 0.9926 - val_loss: 0.8212 - val_acc: 0.8192\n",
-            "Epoch 62/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3825 - acc: 0.9912 - val_loss: 0.8139 - val_acc: 0.8277\n",
-            "Epoch 63/100\n",
-            "50000/50000 [==============================] - 125s 2ms/step - loss: 0.3784 - acc: 0.9923 - val_loss: 0.8304 - val_acc: 0.8121\n",
-            "Epoch 64/100\n",
-            "50000/50000 [==============================] - 125s 2ms/step - loss: 0.3809 - acc: 0.9918 - val_loss: 0.7961 - val_acc: 0.8289\n",
-            "Epoch 65/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3750 - acc: 0.9930 - val_loss: 0.8676 - val_acc: 0.8110\n",
-            "Epoch 66/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3789 - acc: 0.9928 - val_loss: 0.8308 - val_acc: 0.8148\n",
-            "Epoch 67/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3783 - acc: 0.9929 - val_loss: 0.8595 - val_acc: 0.8097\n",
-            "Epoch 68/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3758 - acc: 0.9935 - val_loss: 0.8359 - val_acc: 0.8065\n",
-            "Epoch 69/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3784 - acc: 0.9927 - val_loss: 0.8189 - val_acc: 0.8255\n",
-            "Epoch 70/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3786 - acc: 0.9924 - val_loss: 0.8754 - val_acc: 0.8001\n",
-            "Epoch 71/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3749 - acc: 0.9936 - val_loss: 0.8188 - val_acc: 0.8262\n",
-            "Epoch 72/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3758 - acc: 0.9932 - val_loss: 0.8540 - val_acc: 0.8169\n",
-            "Epoch 73/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3740 - acc: 0.9934 - val_loss: 0.8127 - val_acc: 0.8258\n",
-            "Epoch 74/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3749 - acc: 0.9932 - val_loss: 0.8662 - val_acc: 0.8018\n",
-            "Epoch 75/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3721 - acc: 0.9941 - val_loss: 0.8359 - val_acc: 0.8213\n",
-            "Epoch 76/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3746 - acc: 0.9937 - val_loss: 0.8462 - val_acc: 0.8178\n",
-            "Epoch 77/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3741 - acc: 0.9936 - val_loss: 0.8983 - val_acc: 0.7972\n",
-            "Epoch 78/100\n",
-            "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3751 - acc: 0.9933 - val_loss: 0.8525 - val_acc: 0.8173\n",
-            "Epoch 79/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3762 - acc: 0.9931 - val_loss: 0.8190 - val_acc: 0.8201\n",
-            "Epoch 80/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3737 - acc: 0.9940 - val_loss: 0.8441 - val_acc: 0.8196\n",
-            "Epoch 81/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3729 - acc: 0.9935 - val_loss: 0.8151 - val_acc: 0.8267\n",
-            "Epoch 82/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3735 - acc: 0.9938 - val_loss: 0.8405 - val_acc: 0.8163\n",
-            "Epoch 83/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3723 - acc: 0.9939 - val_loss: 0.8225 - val_acc: 0.8243\n",
-            "Epoch 84/100\n",
-            "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3738 - acc: 0.9938 - val_loss: 0.8413 - val_acc: 0.8115\n",
-            "Epoch 85/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3714 - acc: 0.9947 - val_loss: 0.9080 - val_acc: 0.7932\n",
-            "Epoch 86/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3744 - acc: 0.9942 - val_loss: 0.8467 - val_acc: 0.8135\n",
-            "Epoch 87/100\n",
-            "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3705 - acc: 0.9948 - val_loss: 0.8491 - val_acc: 0.8163\n",
-            "Epoch 88/100\n",
-            "50000/50000 [==============================] - 128s 3ms/step - loss: 0.3733 - acc: 0.9944 - val_loss: 0.8005 - val_acc: 0.8214\n",
-            "Epoch 89/100\n",
-            "50000/50000 [==============================] - 134s 3ms/step - loss: 0.3693 - acc: 0.9949 - val_loss: 0.7791 - val_acc: 0.8321\n",
-            "Epoch 90/100\n",
-            "50000/50000 [==============================] - 135s 3ms/step - loss: 0.3724 - acc: 0.9942 - val_loss: 0.8458 - val_acc: 0.8124\n",
-            "Epoch 91/100\n",
-            "50000/50000 [==============================] - 128s 3ms/step - loss: 0.3732 - acc: 0.9947 - val_loss: 0.8315 - val_acc: 0.8164\n",
-            "Epoch 92/100\n",
-            "50000/50000 [==============================] - 127s 3ms/step - loss: 0.3699 - acc: 0.9950 - val_loss: 0.8140 - val_acc: 0.8226\n",
-            "Epoch 93/100\n",
-            "50000/50000 [==============================] - 131s 3ms/step - loss: 0.3694 - acc: 0.9950 - val_loss: 0.8342 - val_acc: 0.8210\n",
-            "Epoch 94/100\n",
-            "50000/50000 [==============================] - 134s 3ms/step - loss: 0.3698 - acc: 0.9946 - val_loss: 0.8938 - val_acc: 0.8019\n",
-            "Epoch 95/100\n",
-            "50000/50000 [==============================] - 133s 3ms/step - loss: 0.3698 - acc: 0.9946 - val_loss: 0.8771 - val_acc: 0.8066\n",
-            "Epoch 96/100\n",
-            "50000/50000 [==============================] - 164s 3ms/step - loss: 0.3712 - acc: 0.9946 - val_loss: 0.8396 - val_acc: 0.8211\n",
-            "Epoch 97/100\n",
-            "50000/50000 [==============================] - 155s 3ms/step - loss: 0.3689 - acc: 0.9949 - val_loss: 0.8728 - val_acc: 0.8112\n",
-            "Epoch 98/100\n",
-            "50000/50000 [==============================] - 133s 3ms/step - loss: 0.3663 - acc: 0.9953 - val_loss: 0.9615 - val_acc: 0.7902\n",
-            "Epoch 99/100\n",
-            "50000/50000 [==============================] - 133s 3ms/step - loss: 0.3714 - acc: 0.9944 - val_loss: 0.8414 - val_acc: 0.8188\n",
-            "Epoch 100/100\n",
-            "50000/50000 [==============================] - 138s 3ms/step - loss: 0.3682 - acc: 0.9956 - val_loss: 0.8055 - val_acc: 0.8266\n"
-          ]
-        }
-      ],
-      "execution_count": 6,
-      "metadata": {
-        "outputExpanded": true,
-        "scrolled": true
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "## Model Output\n",
-        "\n",
-        "We can now plot the final validation accuracy and loss:"
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "plt.plot(trained_model.history['acc'])\n",
-        "plt.plot(trained_model.history['val_acc'])\n",
-        "plt.title('model accuracy')\n",
-        "plt.ylabel('accuracy')\n",
-        "plt.xlabel('epoch')\n",
-        "plt.legend(['train', 'test'], loc='upper left')\n",
-        "\n",
-        "print(np.max(trained_model.history['acc']))\n",
-        "print(np.max(trained_model.history['val_acc']))"
-      ],
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "0.9956000019311905\n",
-            "0.8320999944210052\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": [
-              "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xd8VfX9+PHX+47sMMMegooILlDEWeusuLVW3KutqK1VO2y1/VZbW3+1rbVqtY4qaq17o8WF4iqCoOBgCSIjzBDIHne9f398TpKbkHGB3Nwk9/18PPJI7jnnnvM599yc92edz0dUFWOMMQbAl+oEGGOM6TwsKBhjjKlnQcEYY0w9CwrGGGPqWVAwxhhTz4KCMcaYehYUTFoRkUdE5I8JbrtSRI5NdpqM6UwsKBhjjKlnQcGYLkhEAqlOg+meLCiYTsertrlORD4XkUoReUhEBojIayJSLiIzRKR33PanishCESkRkXdFZEzcuvEi8qn3vqeBrCbHOllEFnjvnSUi+yaYxpNEZL6IlInIGhH5XZP1h3v7K/HWX+ItzxaRv4nIKhEpFZEPvWVHikhhM5/Dsd7fvxOR50TkPyJSBlwiIhNF5CPvGOtF5G4RyYh7/14i8paIbBGRjSLyaxEZKCJVItI3brv9RaRIRIKJnLvp3iwomM7qTOA4YA/gFOA14NdAP9z39moAEdkDeBK41ls3HXhFRDK8G+RLwGNAH+BZb7947x0PTAUuB/oC9wPTRCQzgfRVAhcBvYCTgCtF5HRvv7t46f2Hl6ZxwALvfbcBBwCHemn6JRBL8DM5DXjOO+bjQBT4KVAAHAIcA/zIS0M+MAN4HRgM7A68raobgHeByXH7vRB4SlXDCabDdGMWFExn9Q9V3aiqa4EPgDmqOl9Va4AXgfHedmcD/1XVt7yb2m1ANu6mezAQBO5Q1bCqPgfMjTvGFOB+VZ2jqlFVfRSo9d7XKlV9V1W/UNWYqn6OC0zf9lafB8xQ1Se94xar6gIR8QHfB65R1bXeMWepam2Cn8lHqvqSd8xqVf1EVWerakRVV+KCWl0aTgY2qOrfVLVGVctVdY637lHgAgAR8QPn4gKnMRYUTKe1Me7v6mZe53l/DwZW1a1Q1RiwBhjirVurjUd9XBX39y7Az73qlxIRKQGGee9rlYgcJCIzvWqXUuAKXI4dbx9fN/O2Alz1VXPrErGmSRr2EJFXRWSDV6X0/xJIA8DLwFgRGYkrjZWq6sc7mCbTzVhQMF3dOtzNHQAREdwNcS2wHhjiLaszPO7vNcAtqtor7idHVZ9M4LhPANOAYaraE7gPqDvOGmC3Zt6zGahpYV0lkBN3Hn5c1VO8pkMa3wssAUapag9c9Vp8GnZtLuFeaesZXGnhQqyUYOJYUDBd3TPASSJyjNdQ+nNcFdAs4CMgAlwtIkER+S4wMe69/wKu8HL9IiK5XgNyfgLHzQe2qGqNiEzEVRnVeRw4VkQmi0hARPqKyDivFDMVuF1EBouIX0QO8dowvgKyvOMHgf8D2mrbyAfKgAoR2RO4Mm7dq8AgEblWRDJFJF9EDopb/2/gEuBULCiYOBYUTJemqktxOd5/4HLipwCnqGpIVUPAd3E3vy249ocX4t47D7gMuBvYCiz3tk3Ej4CbRaQcuBEXnOr2uxo4ERegtuAamffzVv8C+ALXtrEF+DPgU9VSb58P4ko5lUCj3kjN+AUuGJXjAtzTcWkox1UNnQJsAJYBR8Wt/x+ugftTVY2vUjNpTmySHWPSk4i8Azyhqg+mOi2m87CgYEwaEpEDgbdwbSLlqU6P6Tys+siYNCMij+KeYbjWAoJpykoKxhhj6llJwRhjTL0uN6hWQUGBjhgxItXJMMaYLuWTTz7ZrKpNn33ZRpcLCiNGjGDevHmpToYxxnQpIpJQ12OrPjLGGFPPgoIxxph6FhSMMcbU63JtCs0Jh8MUFhZSU1OT6qQkVVZWFkOHDiUYtLlQjDHJkbSgICJTcWO6b1LVvZtZL8CduDFiqoBLVPXTHTlWYWEh+fn5jBgxgsYDYnYfqkpxcTGFhYWMHDky1ckxxnRTyaw+egSY1Mr6E4BR3s8U3DDAO6Smpoa+fft224AAICL07du325eGjDGplbSgoKrv40aBbMlpwL/VmQ30EpFBO3q87hwQ6qTDORpjUiuVbQpDaDyTVKG3bH3TDUVkCq40wfDhw5uuNsZ0MZFoDBHB7+u4jE5tJMrmihBbK0NkBnzkZAbICfqpDkcpqwlTWRvB7/ORFfSRFfATjsaoDEWpqo2QEfDRMztIz5wgKFTURqiojVAVilIbiRGKxIjG6qbaFoJ+ITvoJyvDT4bfhwgIggjEVFF1v0Pee2ujMapDUSprI9RGYvTNzaB/j0x652RQVF7Lmq3VFG6t4pg9B7DP0J5J/Zy6REOzqj4APAAwYcKETjdYU0lJCU888QQ/+tGPtut9J554Ik888QS9evVKUspMR6oJR1lfWkMkGqNPbga9cjLw+wRVJRxVFCUz4G/2vZFojOqwu8GEozHCESUci+GPu3GWVocpqQpTWh0mporPKzmW14QpqXbLe+cE2aVvLiMLcglHY2worWFDWQ2xmJKTESA3009FbZQ1W6pYs7WKytoIGQE/mQEffhFiqkRVqY3EKPP2WRuO0Ts3SN/cTHrlBN3NLuhHBNaWVFO4pZoNZTUE/EJOhp+sgJ+YKpGYEokqfp+7SQZ8PkqrwxRV1LKlMgRAht/dhDMCfgI+d64ZAR9Bf91vHxl+HxkBH+FojKLyWjZXhKgKRdz5ZPgJBnzUhmPURqKEIjFiCoq78fp9gl8Exd3IuzIRKMjL7NZBYS1u2sQ6Q71lXU5JSQn//Oc/twkKkUiEQKDlj3j69OnJTlra2FxRS+HWaob0yqYgLwMRIRSJsa6kmq1VIfr3yGJAfiZ+n7CutIYv15bydVEFGX4fORkBsjNcTWos1jgnF1Pw+8Dv8xHwCetLa1hRVME3myupqI2g3g1oS2WYzRW1jdIk4m56tZFY/bIMv4/cTD+ZAT+haIxaLxBEYjuf1wn4JOH9iMDAHln0yAoSirrcasQLQiJCZsBHj+wgfXIzCPp9lFSFWLyhjNKqMNXhKDXhKIrbx7A+OYwf3otITKkOuXU+EQJ+IeATojEXFCOxGLv0zWHCiN4U5GXiE6E6HKU6FCEcUyLRGJGoCyahSIxQ1AXI2kiM8poIQb8wemA+h+dlkp0RoCbsctbhaIzMgJ/MoAsiPqE+YNYFJ4A+ORn0y8+kV04G4WiMqpDL6edk+MnLDJKXFSAWUy9NUYIBH3mZfrKDAcLRmAu8VSEQIT8zQF5mgOwMP1lBH5kBv5cBcN+HSFSpCUepCrtA5cYddd8rEalPY0bAV/+Tk+EnNyNA0O+juLKWTeW1bKkIUZCfybDe2Qzpnd1ipqI9pTIoTAOuEpGngINwk4dvU3XUFVx//fV8/fXXjBs3jmAwSFZWFr1792bJkiV89dVXnH766axZs4aamhquueYapkyZAjQM2VFRUcEJJ5zA4YcfzqxZsxgyZAgvv/wy2dnZKT6zjlEbibJycxVfF1VQUROpz632yAoypHc2Q3tlU1wZYt6qrXy6aisVtRGG98lhl745lNdEmLF4IwvWlFA34G920E9+VoCiilriBwH2CeRkBHY6x9gvP5NdC3LZpW9OfZXA+GEurUN6ZRMM+Nji5YZrIzEyAz4yg+6fuaI2QkVNhNpIlMyAv/6GkB30kx10N7YMv7u5Bfxezt0LVD2ygvTKCdIzO1h/AwLIywrQKztIToafsuoIK4srWVlcSYbfx8CeWQzsmUXA56Mq5Ko8cjICDO6VtVM3GPUCp68Dq3/SycCeWeyVomMns0vqk8CRQIGIFAI3AUEAVb0PmI7rjroc1yX10vY47u9fWciidWXtsat6Ywf34KZTWr5Et956K19++SULFizg3Xff5aSTTuLLL7+s7zo6depU+vTpQ3V1NQceeCBnnnkmffv2bbSPZcuW8eSTT/Kvf/2LyZMn8/zzz3PBBRe063kkUygS46uN5SxeX8b60hrWl9ZQXFFLVtBPj+wA+VlB+uRk0Dcvgx5ZQVYWV/LF2lK+XFvKyuIqognmcPvlZ9I7J8gHy4qoCbsc+L5De3LtMXswZlA+60trWL2lirLqMIN7ZTOsTw69soNsKq9lfWk1pdVhRvXPY68hPdljQD4xdbnbqlAUweXeRNzNzufVA8dUvRxsjIL8THpkdd7nRHrmBNkvpxf7DWuuSrKtKZ8TJ97nZLqfpAUFVT23jfUK/DhZx0+liRMnNnqW4K677uLFF18EYM2aNSxbtmyboDBy5EjGjRsHwAEHHMDKlSs7LL3xaiOu6NwjK4jPJ8RiysriSr5cV0bh1qr67UKRGJsratlcHmJtSTVLN5QTijZUkxTkZdA3N5PaSJSymghl1eFtqjYG9shi7yE9OXGfQezeP4/d+uXRKyeITwSfCCXVIdaVVLN2azU5GQEOHNGHYX2yEXH19JvKaxGB/vlZO3XOnfkmb0xH6xINzdujtRx9R8nNza3/+91332XGjBl89NFH5OTkcOSRRzb7rEFmZkMuzu/3U11dnbT0lVaH+XTVVgpLqimvCVNeE6FwazVL1pexYnMl0ZgiAj2zg4QjrgdGc3rnBCnIy2RgzywuPXwE+wzpyV6DezZbNaGqlNdGKK4IUVIVYmjvHPrlt55zHdgziz0H9mh2nYgwoMfOBQNjzLa6XVBIhfz8fMrLm5/VsLS0lN69e5OTk8OSJUuYPXt2h6VrzZYqnpq7mqLyWmIK0ZiydEM5izeUNaprD/jcDXbMoB4cv9dAeudmUFoVYktViIDPx9jBPdhrcA9GFuTWN+AFfELAn/hjLiJCj6yglyvPbXN7Y0xqWFBoB3379uWwww5j7733Jjs7mwEDBtSvmzRpEvfddx9jxoxh9OjRHHzwwe1+/GhMeX9ZEVW1UTICPqKxGC98upYZizciIvTPz6y/mY8oyOHaY/bgwJG92b1fHvlZQbKCPnswzhgDdME5midMmKBNJ9lZvHgxY8aMSVGKOlbTc/109VZuenkhX6wtbbRdr5wg500czoWH7MKgnunRi8kY0zIR+URVJ7S1nZUUupCK2ghbKkNc+9R8cjMDlFSF+e8X6xnQI5M7zh7HmEE9CEVihGMxxgzsQXZG8vs0G2O6FwsKXUAo4p6UdU+XRpm/ppSKmgihaIzLv70rVx89itxMu5TGmJ1nd5JOKKZKVW3EjbvijYcCMKBHFoGeWbx33f4pTqExpruyoNCJRKIxtlSGKK4MEfb6/GcF/fTOzaBfXiYZAR9brEHYGJNEFhQ6gWhM2VRew+aKEKpKXmaAwb2yycv04/fZjKnGmI5jQSGFVJWymjDrSmoIR2P09gbsygpaA7ExJjUsG9oO6kZJ3R7RWIzVW6q45c9/I1RTzW798hjWJ8cCgjEmpSwotIPtDQrVoSjLN1VQVh3hqYfvY3Cez3oPGWM6BbsTtYP4obOPO+44+vfvzzPPPENtbS1nnHEGv//976msrGTy5MmsWr2G2nCEK6+9jmhVCRvWr+foo4+moKCAmTNnpvpUjDFprvsFhdeuhw1ftO8+B+4DJ9za4ur4obPffPNNnnvuOT7++GNUlVNPPZX333+foqIi+vQbwJ/uf5zczAA9/WEK+vTmnrvuZObMmRQUFLRvmo0xZgd0v6CQYm+++SZvvvkm48ePB6CiooKvvvqKPcdP5J23Z5Db42bO/d7p7HbEESlOqTHGbKv7BYVWcvQdQVW54YYbuPzyy+tfry2pZktliDfe+4j5/3uHG3/7W4455hhuvPHGlKbVGGOasobmdhA/dPbxxx/P1KlTqaioAGDBkhUsW7WWaEUxuw3qw4UXXsh1113Hp59+us17jTEm1bpfSSEF4ofOPuGEEzjvvPM45JBDiMaUYFYO9zwwlY0rC7l48hn4fD6CwSD33nsvAFOmTGHSpEkMHjzYGpqNMSlnQ2cnSWl1mNXFleRnBd0E7+00PEVnPFdjTOeX6NDZVn2UBOFojMKtVWRl+BnWp/0CgjHGJJsFhSTYUFpDTGFY7xz8PgsIxpiuo9sEhc5SDVZRG2FrVYh+eRntPmRFZzlHY0z31S2CQlZWFsXFxSm/acZUWVdSTYbfR//8rHbdt6pSXFxMVlb77tcYY+IltfeRiEwC7gT8wIOqemuT9bsAU4F+wBbgAlUt3N7jDB06lMLCQoqKitoh1TuuvCZMaXWEvnkZLC1p/4HtsrKyGDp0aLvv1xhj6iQtKIiIH7gHOA4oBOaKyDRVXRS32W3Av1X1URE5GvgTcOH2HisYDDJy5Mj2SPYOW7axnIvu/pDDdy/gwYv3TmlajDFmRyWz+mgisFxVV6hqCHgKOK3JNmOBd7y/ZzazvkuoCUf5yZPzyc0I8P++u0+qk2OMMTssmUFhCLAm7nWhtyzeZ8B3vb/PAPJFpG/THYnIFBGZJyLzUl1F1Jw/TV/Mkg3l3HbWfu3elmCMMR0p1Q3NvwC+LSLzgW8Da4Fo041U9QFVnaCqE/r169fRaWzVjEUbefSjVfzg8JEctWf/VCfHGGN2SjIbmtcCw+JeD/WW1VPVdXglBRHJA85U1ZIkpqld1YSjXP/CF+w1uAe/nDQ61ckxxpidlsySwlxglIiMFJEM4BxgWvwGIlIgInVpuAHXE6nLeOWzdWyuqOU3J40hM2DTaBpjur6kBQVVjQBXAW8Ai4FnVHWhiNwsIqd6mx0JLBWRr4ABwC3JSk97U1UembWS0QPyOWTXbZpBjDGmS0rqcwqqOh2Y3mTZjXF/Pwc8l8w0JMsnq7aycF0Zt5yxt41tZIzpNlLd0NxlPTJrJT2yApwxvmmHKmOM6bosKOyADaU1vPblBs4+cBg5GTYlhTGm+7CgsAMen7OKmCoXHjwi1Ukxxph2ZUFhO9VGojwxZzXH7Nmf4X1zUp0cY4xpVxYUttMbCzdSXBniwkNGpDopxhjT7iwobKfHZ69iWJ9svrV7QaqTYowx7c6CwnZYvqmcOd9s4byJu+CzGdWMMd2QBYXt8MScNQT9wlkTbE4DY0z3ZEEhQTXhKM99sobj9xpIQV5mqpNjjDFJYUEhQa9+vp6ymgjnH7RLqpNijDFJY0EhQY/PWcWu/XI5eNc+qU6KMcYkjQWFBKzcXMn81SWce+BwG+fIGNOtWVBIwMylmwA4fq+BKU6JMcYklwWFBMxcWsSu/XLtCWZjTLdnQaENVaEIs1cUc/Rom2rTmLRU/DXUlqc6FR3GgkIbPvq6mFAkZvMvm+6hshiqt6Y6FV3HivfgnwfD8z9MdUo6jAWFNryzZBO5GX4mjOid6qSYdKPa/PLKzS2vAyhbB4+eCnPub7w8XA0PHAkPHQ/RyI6lp2zdtstjMVj6GoRrtl23cSHEott/rEStng0f3ePS0N7Wfw5PnQ/ig69eh3UL2v8YiQpXw6s/hS3fJP1QFhRaoaq8u7SIw3YvsDmYTccq/ARuHQ4bvmi8fP3ncNsesOCJ5t+3aTE8eBx88x68+X+weXnDull3Q+lq2LwUFjy+/WmadRfcsS9sWdF4+edPw5PnwFPnQqjKLVOFt/8A9x7q3tfeYlF47y/w8Anwxq/htV82DpSLX4XHz4Ky9Tu2/60r4fHvQVZPmPKe+/3+X1vevmITFM6DmtIdO15rStbA1ONh3sOw8sP2338TFhRasWxTBWtLqtO36mj1bJh9X3JyYaZ1i6dBbZm78cX74G+gUfjw79tel28+cKWAWATOfx4C2fDfn3k5/PXw4e0w5hQYeiC8e2vDDTwRNWXeMcPbBqTPnnA3zRXvuhtxTSn89+fwwW0QzIV5UxunNRZ1OfBnL4Wv3oBouPVjV2+FL5+HD++AuQ/CZ0/DY6fDzFtg7zPhoCth7r/g3T+5c33/Nnj6fFj2pqv22Z5SkSosfAkeOQUitXDhC9B/TzjoCljyqiv5xIvFYM4DcNd4ePAYF8hvHwtv/rb146yZC09fAKVrW99u1SxXutvyDZz3NOx/YeLnsoNs2rBWzFziuqIeObpfilOSAqVrXe6veits+BxOuQv8bXxdYjFYPQuGHwK+7SxZhavhkZNhr9Ph0J/seLpbE6py/9h7n9ly+raugtdvgKEHwAGXQk6KHlZc8S4gLjhsWgz9x7hc/6KXYcDesPFLd9MbPcltv2WFuyH3Gg4XPOd+H/NbmP4L+OI5+PptFyy+80d3bR85ET6+Hw7/aWLp+fh+913ouzsseBKOvMF9hiVrXDA68gbouxu8MMWVJmpK4LBrYeA+8PwPYMU7sPuxbl8LX3TXISMPFr4AOQVw0m2w1xmNj7nsLfjgdlgzxwXCeMEcOO0eGHe+ex0qh/f+DMtnwNpPYJ/JsMuh8Oq18N6tcPT/tX5+0bD7zGfeAuvmQ8FoOOsR6DfarT/oCldN9f5tcNbDbtmGL13QXTMHdjsaDrjENUqv/MCVjkafCLscsu2xQpXuMylZ5a7tJf+F/Ga6u29Z4aoBe4+Ac5+EglGtn0M7saDQiplLN7HnwHwG9cxOdVI6ViwKL17uckoTp8DHD7hc65kPQaCVcZ/mPwavXA17ngzf/RdkbEcX3ll3w9p5ULTE/aMn42b80T0w84/uBjD+/G3Xr/+sIae79L8ul77v2TDqOzBgLPQaAb42CtfffOBKWBk57saV0xcK9oA+u0IgI7F0Vm1xaTnoCvj03+7GeOa/4H93uM//vGfgoePgo7tdUFB19c2+AFz0EvQY7PYz4fsuVz/95+6cDv+pu8H0HgGjjocP/g77Xwxbv4FPH4NwlbuRDxjbOD01pTDrH7DHCbDvZHjuUlc9tdvRruoIdcv7jHTpe+nHcNzNcNg1EAm5m/68h11QiMVcNUy/MXD5e/D1O/DOH+G1X7n9B7PcMWvLXS4/qyd862fuGvQf4wJ7bTlk94bcvg1pPPlOl87Fr8AxN8LhPwMR9516/zaXUdn9mG0/64UvuSD19UyoLYWew+D0e911j8845PSBiZe50srwQ1ywXvmBS8fp98F+57jjgbtud+4H7/4/uPiVbY854/dQshqO+4Mrsf37NBcYcpsMx//F8y6QX/QS9Oy4QTgtKLSgvCbMvJVbueyIXVOdlI73vzvdF/7Uu11xtc9u8Pqv3Jf3yBtg5BEN/wDx5j/m/kmW/BcePQXOfQryEihlla51VRtDD4TCuTD7Xjj6N9tuV/SVqzsOZsPkx9ouucSLRuATL4f37p9caaHuBgQuh/nMxS79U94DjcGc+9xN79NH3TYZeXDKnbDP95o/xtwHYfp17r1Nid/lsocdCMMOhsHjXW4+q8e2237zHqCw93fBH3Q3//0vgs+ecrnRnkPcjeet37rGz02LXS73xNsaAgK4m9rJf4d/HQV5A+BbP29Yd+xNcO9hcPcEqCp2VU3+IHz+jLshHnm9u8mDux41pXDUDS4HndUL5j8Oux7l0jT80IZtx5wCo09qCJ6BDBeAZ93tqrDWzHaB/3tTXQAZfYILnv8+FT57EiZc6t43b6orbVzwgiu11cnMh/wB235m/gCc9SiUFkLvuPHJTvgrrP0UXrgMfjSn8fdx+dvw7MWQNxDGnuoCzx7Ht5zxOeQq13j/2nXu2h37OxdUm2ZgMnLg8GtdW8fKD2HE4Q3rVn7oSl0HXQGHXQ2Dx7mMyL9Pgx+8CRm5DdsufMEFoA4MCACirfVi6IQmTJig8+bNS/px3l68kR88Oo8nLjuIQ3frwhPqVG911Q7l66B8g/vS9R4BvUe6G0jTm3vhJzD1Oy63f9YjDes/exreuMHdQPrt6XKB485reF/RUrhnoque6D3S5fKye7sbWMVGd1M58yEYddy2aXz+h7BoGlz1sWscXfE+/PQLl0sEV7X0wd9cLs2fAeFKOOKXzQeOlix+1dUz15V8jv8THPIjt27pa65+t98YOP9Z6DGo4X2hSti0xFXXfPyA+zyv+czdQOuowjt/cGncYxJ89wG3LFwN5euheDls/so1Eq+Z4252dTJ7uGB49n8aSlavXANfvgC//MZ93nfu64JKtBaunu9uSDWlcPternqicJ6rWrj09eZLMoumQY8hjW+u4Oq9V/3PXcd9znIlxP/d4W58kRoYOtHd5N//q8sInOM1Tv/3Fy4DcM7j8J8z4dR/uKDVkuKv4R/7w1G/cbnyWAR+NLshJ67qAldNKVw1z5Xk7tjHlVguejmx69uaTUtcg/fEy+CEPzcsf/gkV0VzzYLWS8Dxvnnf9bLa/ZjWq0jD1a600HcUXPpftyxU6QIxClfOaggAX70BT0xu/J3ctAT+eZALagdN2e5Tbo6IfKKqE9raLqklBRGZBNwJ+IEHVfXWJuuHA48CvbxtrlfV6clMU6JmrygmI+Bj/+FduCtqJAT/OMDdWJoz6nj3j113g6sshmcvcTmnU+5oHDD2OxvGnuYa/ObcBy9dCbn9YZRXTzz/P676Yt+zIa+/Kw6/9Vu37+GHuJvhqz+DH89pXK20ejZ88SwccZ0LVkdc56oAPn7A/V20FJ65yOUu9z0bvnMLzLjJ3ah2ORR2Oyqxz2LeQ5A/2P3jbV7mGkHHXwCbFrlzHrgPXDRt25x7Rq67mQ49wNX7PjHZ3dj2ndywzfTrXEPn/hfDSbc3lGCye7kAM2T/hm1jMShe5noVla11aZn/mKsmOvgKt82Kd2HEt9x+8ge4/X58P+x3rgsI4ALm/hfB7HvAF3QlmJaqtsae2vzy7/xh22XH3exysQseh4Uvu2sIroRYZ/z57nxf+hEEstz3ojV9d4OR33bVONFaV7UYf0MVcVVbz1zkqmUqN0PlJvjW1Nb3m6j+e7prPW8qHPJj9xmungOrPnTfh0QDArjgmIhgtqvCev1XrkRSttZVA279xv1vxJcI9jjelbY+uscFLn8QFr0ESMvXLplUNSk/uJv818CuQAbwGTC2yTYPAFd6f48FVra13wMOOEA7wsl3faCT75vVIcdKmuXvqN7UQ/WDv6uu/1y1fJNq8deqy99WffsPbt1LP1aNxVQjYdVHTla9uZ9q4bzW9xuuUb1zvOqd49zfkZDqX3ZXfeIYPxUKAAAeO0lEQVTclt+z4n13vLf/2LCsplz13sNVb9tTtbaiYfl/zlK9dYTqJ/9W/eMg1b/sprrsrYb1tRWqd090y8vWNz5OZbHqivdUv57pzktVdfNyd+x3/+xeF37iXj9/meqfhrlzqShq69NUjUZV/3Gg6r2HNex7yWtuX69d37Bse009wX0G4RrV4hVuf7Pvb1hfuk71sTPdtYu3dZXqLUNUZ966Y8dNRNEy1VUfNV4Wi6nec4hL57PfT2w/X77gtr9rf9VoZNv10Yi7Dvcernr73qr/OnbHP8/mlBS67/aLV7rXj09237H47117C1Wr3jZa9aae7tzvO0L1qzeb33bJdLfNZ0+713dPVJ16YrsmB5inCdy7k1lSmAgsV9UVACLyFHAasCg+JgF1WbOeQDNPxnS80uowC9eV8pOjO6a1f4dVbXE5xpaKsV+94XJyE6fE5c77uUbP3Y52L9//q6sPrix2RePT74UhBzS/vzqBTDjxL67qYNY/YMBeLmfXXONtnZHfclUU/7vDNcpl93a57o1felUncTmnI66Dh46FaVe5+vezHm5cV56R66q2HjgK7jvcNWSKz1U/lBU2bLfvOXDy7S6H6As0VHEM2R/Gnu7aC/IGwoUvbtvI1xyfz+U0X7na1fsPGud6t/TfC479ffPtLIk44jrXxXLB44C3j12PbFjfY5DrUdRUr+Hwi6WNP7v2VrA7sHvjZSIu5/3GDa70kojRJ7mG5gMva/776vO7KslXrnavT7ptxz/P5vQc4nLhs//pqn6+et1VZyXzswtmwaRbXSn6oMvd+bd0TqOOd+01/7vL9S4rWuLaiFIgaW0KIvI9YJKq/tB7fSFwkKpeFbfNIOBNoDeQCxyrqp80s68pwBSA4cOHH7Bq1aqkpLlOytsTlr8NM37nGuNa6oa2cRHcd5hrpBu0n6uXPvynrsoCXD3tXePcF+38Z5rfh6prgPviWff6oCsa17m25ekLYNkMGOQ90PSzxY3r2psq3wD/mOAa1yo3u/d8byqMOXnbbV//tSuCH3l9y/tcNsNVvWjM/QRzXIAauI9rsH73VtdjpWydq2Y665GG9275xjUEHvUbGLh34uccroE79nYBIW+Aaxy97G3XcLyjVOHBY11gHbiv6xL504Xte1Nsb5GQ6zm0x/Htl85IrauHzymAKz5o//OvLHb7D1e579ZPv3SZk87i08dcRmj4oa5B/mdLmm9U30Gdok0hAecCj6jq30TkEOAxEdlbtXH3DVV9AFfVxIQJE5LeMj7nmy1k+JPYnqDqGgfrbsYn/LnxP8B7f3HPBjx2huuREJ9LrrPIa4Db7xzXA2XWXa5xsO6mvnmZeyrz0KtbToeI6+tdU+b+/s4ft+88jv+TuzGvmeN6ZrQWEMDVyR/1a5fDzMhzud+W6mgn/b+2jz/q2IY2jaZ2P8YFyud/6Bp2D2wydk2fka7v9/YKZsHEy13XVnD1xjsTEMB99t/+pSs5lax2XXI7c0AA16uo7hmJdttnJlw63ZVuk3H+uX3h0Ktc77MJ3+9cAQFcO9U7f3TP+oz4VrsGhO2RzKCwFhgW93qotyzeD4BJAKr6kYhkAQXApiSmq02zVxQzbngvsoLtPLSFqmtQ/PB2d8MWn8vh7nF8Qx/qDV+4XMK4C1xj03/OdP8oTb/AS6fDsIPgpL+51y9e6fb97V+5LnLL3nDLR32n9TQFMlsuSbSl1zD49nXwzi0wPsEnLSdOcc88jD7BlXCSafdj4IoPofBj2OWw9tvvgT9wPY16DXefd3sY9R1XStjweeOqo3TTJ8ldwA/9ietldfCVyT3Ojghkus4GM37nuiOnSDKHuZgLjBKRkSKSAZwDTGuyzWrgGAARGQNkAUVJTFObymrCfLm2lIN37dv2xtsjXAMvX+XqTHP7w2n/hF8sgx5DXcmgrhpv7kOuz/jxf3Q9g4qXw5PnuuJ6nZI17uYx+oSGZYf+xBWL5z7kXn/1hqub7BUfl5Pg8J+5Lpr990xse3/AVQklOyDU6TnEPSnbnjnPnD6uBHfxK42fddgZIu7Zgd4jYLdmHrIy7SMj13VlTtWT6m2ZOMU9/7Dv2SlLQtKCgqpGgKuAN4DFwDOqulBEbhaRun5WPwcuE5HPgCeBSzRZjRwJmrdyCzGlfedirhvQasF/XP/677/uGmVzC9xDLmtmu4fFakrdw0N7n+lKBrse6R4gW/0RfP5Uw/6+et39Hn1iw7IBY2H341zXxfKNbsyUPY5vv3NoiUjyA09nNGjf9i/e736sC7C57ZwhMV1HRq5rG0xmA3gbkjognqpOV9U9VHU3Vb3FW3ajqk7z/l6kqoep6n6qOk5V30xmehIxe0U7tyeEqlzbwJYV7gnfo3/TuPfF+AtdD5j3/uIeEAtXuuqJOvtOdtUKH97RMATx0unuoZimjdCHXQ2VRfDiFDdWzB7tXOdrjOn2bJTUJmavKGbcsHZsT5jxO/ew0tmPNa7uqRPMcqWFlR+4BrDB+zd+2EnEDU+w5WvXuFxT5sbXaW5fI77lqmVWvOvG3Gmra6kxxjRhQSFOeX17QjtVHX39jjfOyZWtNx7ufzHk9oPqLdv2kgE31EDf3V0D9fK33PDF8VVHdUQaehvtftz2j1RqjEl7FhTiLFhTQkzhwJHtEBSqt7rRIgtGuwbE1mTkuP7yBaOb73Xg87t6xg1fwNs3u1LAsInN72vs6a67Xd2QCcYYsx0sKMRZtK4MgL0H99z5nb3+a/cw0ncfcA/KtGXCpW5AuJa23WeyG9Rs60rXVtBSKcAfcCNj7mzfeWNMWrKgEGfR+jIG9cyid26C4963ZOsq11vooCvc07vtIZDRUDXUXHuCMca0g1Q/0dypLF5fxphBzYxvv70+fgCQ9n9A5sAfun73o09q3/0aY4zHSgqemnCUr4sqGbuzQaG23D1ZvNfp7T85hj/gGp3bmv3LGGN2kN1dPMs2VhCN6c6XFOY/7oZxOPhH7ZMwY4zpQBYUPIvXu0bmMYPyd3wnsaibgGboRBja5mCExhjT6VhQ8CxaX0ZOhp9d+u7E4+Vfve5mVjrESgnGmK4poYZmEXkBeAh4remw1t3FovVljB6Yj9+3nQOnrZ7tJqcpXu6eNO45DPY8JTmJNMaYJEu099E/gUuBu0TkWeBhVV2avGR1LFVl8foyTt2vmXkLWrNqFjxykhv+uscQNxftt37WMEevMcZ0MQndvVR1BjBDRHriJsaZISJrgH8B/1HVcBLTmHRrS6opr4lsXyNzZTE89wM31PEP3+68Q/EaY8x2SLhNQUT6ApcAPwTmA3cC+wNvJSVlHajuSeaEg0IsBi9eDlWb3RSPFhCMMd1Eom0KLwKjgceAU1R1vbfqaRGZl6zEdZTF68sRgT0HJtjzaNZdbmC6E2/ruMlijDGmAyRa+X2Xqs5sbkUiE0F3dovXlzGiby65mQl8HLUVbh7VMac0P6KpMcZ0YYlWH40VkV51L0Skt4h0m36Xi9aXJf58wrpP3dDV+1/c+SdXN8aY7ZRoULhMVUvqXqjqVuCy5CSpY5XXhFm9pSrx4S0K57rfNoGNMaYbSjQo+EUassUi4gd2cijRzmHphnJgOxqZ18x1U2Fa47IxphtKNCi8jmtUPkZEjgGe9JZ1ed9srgRgt355bW+s6koKLU1wY4wxXVyiDc2/Ai4H6saCfgt4MCkp6mDrSmoAGNQrq+2Nt6503VBtXCNjTDeV6MNrMeBe76dbWVdSTb/8TDIDCcxnXNeeMPTA5CbKGGNSJKHqIxEZJSLPicgiEVlR95PA+yaJyFIRWS4i1zez/u8issD7+UpESprbTzKtK61mcK8EpssEFxSCudB/bHITZYwxKZJo9dHDwE3A34GjcOMgtRpQvMboe4DjgEJgrohMU9VFdduo6k/jtv8J0OETC68tqU78obU1H8OQ/VueH9kYY7q4RBuas1X1bUBUdZWq/g5oa07IicByVV2hqiHgKeC0VrY/F9eA3WFUlXUl1QzumUBJIVQFG7+0RmZjTLeWaEmhVkR8wDIRuQpYC7TVXWcIsCbudSFwUHMbisguwEjgnQTT0y62VoWpCccSqz5avwBiEWtPMMZ0a4mWFK4BcoCrgQOAC4CL2zEd5wDPqWq0uZUiMkVE5onIvKKionY76LqSaoDEgkL9Q2vW88gY0321GRS8toGzVbVCVQtV9VJVPVNVZ7fx1rXAsLjXQ71lzTmHVqqOVPUBVZ2gqhP69evXVpITttYLCkOaCwqhSvjP9+D9v0JNmQsKvUdCXvsd3xhjOps2q49UNSoih+/AvucCo0RkJC4YnAOc13QjEdkT6A18tAPH2CkNJYVmnlEoXu5GQl3+Fsy6282/PPqEDk6hMcZ0rETbFOaLyDTgWaCybqGqvtDSG1Q14rU/vAH4gamqulBEbgbmqeo0b9NzgKdUVXfoDHbCupJqMgM++uQ2M2JHqMr9PuYmWDPHzb+865EdmTxjjOlwiQaFLKAYODpumQItBgUAVZ0OTG+y7MYmr3+XYBra3bqSGob0ykaaG+007MW+XQ51U2yWb4RcqzoyxnRviT7RfGmyE5IKa0uqGdK7hUbmsKtaIpjjfucP6JhEGWNMCiU689rDuJJBI6r6/XZPUQdaV1LNUaP7N7+yrvooI7fjEmSMMSmWaPXRq3F/ZwFnAOvaPzkdpzYSZVN5bcvdUeuqj+pKCsYYkwYSrT56Pv61iDwJfJiUFHWQjaW1QAs9jyCupGBBwRiTPhJ9eK2pUUAL9S5dQ6vPKACEvaAQtOojY0z6SLRNoZzGbQobcHMsdFltPs0cqgR/BvgTrWEzxpiuL9HqowSHEe066oLCwJ4tVB+Fq6w9wRiTdhKdT+EMEekZ97qXiJyevGQl39qSagryMskKtjAMdqjKeh4ZY9JOom0KN6lqad0LVS3Bza/QZa0tqWZIa1NwhiutpGCMSTuJBoXmtuvSle3rStqYcS1UBcEEZ2QzxphuItGgME9EbheR3byf24FPkpmwZHKT69S0HhTCVn1kjEk/iQaFnwAh4GncDGo1wI+TlahkK6kKUx2Oth0UrPrIGJNmEu19VAlcn+S0dJiGZxRaaVMIVUGPwR2UImOM6RwS7X30loj0invdW0TeSF6ykiuhGdfClfbgmjEm7SRafVTg9TgCQFW30oWfaC6qcENc9MvPbHmjUJUNcWGMSTuJBoWYiAyveyEiI2hm1NSuorI2AkB+VrDljaxNwRiThhLtVvob4EMReQ8Q4FvAlKSlKskqaqMA5LT04FosZr2PjDFpKdGG5tdFZAIuEMwHXgKqk5mwZKqoiZCb4cfna2bGNYBIkwl2jDEmTSQ6IN4PgWuAocAC4GDgIxpPz9llVNZGyMtq5dRtgh1jTJpKtE3hGuBAYJWqHgWMB0paf0vnVRGKkJvZSlCon2DHnmg2xqSXRINCjarWAIhIpqouAUYnL1nJVVETIa+1oFBXUrDqI2NMmkm0obnQe07hJeAtEdkKrEpespKrsraNoBD22hSs+sgYk2YSbWg+w/vzdyIyE+gJvJ60VCVZRW2EYbmtlAJsfmZjTJra7uk4VfU9VZ2mqqG2thWRSSKyVESWi0izw2SIyGQRWSQiC0Xkie1Nz46oaKukYPMzG2PSVNKGvxYRP3APcBxQCMwVkWmquihum1HADcBhqrpVRDrkKem2q4/qSgpWfWSMSS/bXVLYDhOB5aq6witVPAWc1mSby4B7vGEzUNVNSUxPvcraaOu9j6ykYIxJU8kMCkOANXGvC71l8fYA9hCR/4nIbBGZlMT0AFAbiRKKxsjLbOFpZnBPM4OVFIwxaSfVs6cFgFHAkbgH494XkX3iB98DEJEpeMNqDB8+vOk+tkulN8RF6yUFr/rISgrGmDSTzJLCWmBY3Ouh3rJ4hcA0VQ2r6jfAV7gg0YiqPqCqE1R1Qr9+/XYqUXWD4bXeplAFCARamW/BGGO6oWQGhbnAKBEZKSIZwDnAtCbbvIQrJSAiBbjqpBVJTBMViQSFkDcYnrQwNpIxxnRTSQsKqhoBrgLeABYDz6jqQhG5WURO9TZ7AygWkUXATOA6VS1OVpqgISi0OcyFDXFhjElDSW1TUNXpwPQmy26M+1uBn3k/HaK+pNDWgHj24JoxJg0ls/qoU0q4TcGGuDDGpKG0CwoVNYlUH1lJwRiTntIvKCTc0GxBwRiTftIuKNQ/p5DR2sNrlfbgmjEmLaVdUKioDZMV9BHwt3LqVlIwxqSpNAwK0darjsDaFIwxaSvtgkKbI6RCw8NrxhiTZtIuKFTUtjE/M3htClZSMMakHwsKTUVCEItYm4IxJi2lXVCorI2Qn9AEOxYUjDHpJ+2CQpslhXC1+21BwRiThtIuKFS2FRTqZ12zhmZjTPpJu6BQURshv7XB8Kz6yBiTxtIqKESiMWrCMXIzbH5mY4xpTloFhYapONsY4gJsmAtjTFpKq6BQEXKD4bVafWQlBWNMGkuroFCZ0KxrXlCwNgVjTBpKq6BQnshcCiGv+sh6Hxlj0lBaBYWEZ10DKykYY9KSBYWmQhYUjDHpK62CQnlCJYVK8GeAv41B84wxphtKq6CQWENztZUSjDFpK02DQivPKdhcCsaYNJbUoCAik0RkqYgsF5Hrm1l/iYgUicgC7+eHyUxPeW2EDL+PzEBb8zNbScEYk56SVnEuIn7gHuA4oBCYKyLTVHVRk02fVtWrkpWOeG4wvFYCAtj8zMaYtJbMksJEYLmqrlDVEPAUcFoSj9emytooea09zQze/MxWfWSMSU/JDApDgDVxrwu9ZU2dKSKfi8hzIjKsuR2JyBQRmSci84qKinY4QRW1kdYHwwP38JqVFIwxaSrVDc2vACNUdV/gLeDR5jZS1QdUdYKqTujXr98OH6yiJtJ6d1TwSgoWFIwx6SmZQWEtEJ/zH+otq6eqxapa6718EDggiemhMtTGBDtgvY+MMWktmUFhLjBKREaKSAZwDjAtfgMRGRT38lRgcRLTQ0VtJIE2Bet9ZIxJX0nrfaSqERG5CngD8ANTVXWhiNwMzFPVacDVInIqEAG2AJckKz3gVR+12aZgvY+MMekrqWM5qOp0YHqTZTfG/X0DcEMy0xCvzfmZYzGI2BPNxpj0leqG5g4TiymVoWa6pJZvgJevgooiFxDAgoIxJm2lTVCoDNUNhtfk4bVv3of5j8HzP4DacrfMGpqNMWkqfYJC/fzMTUoKFRvd72/egzf/z/1tJQVjTJpKm6BQ0dKw2RUbIZAF4y+EL551y6yh2RiTpiwoVGyCvP5w4l9h4D5umQ1zYYxJU2kTFFqcS6FiI+QNgGA2TH4MxpwKg8elIIXGGJN6aTO9WKslhT67ur/7jISzH+vglBljTOeRNiWFippW2hTy+qcgRcYY0/mkTVCo65LaqPooGoaqYld9ZIwxJn2CQrPVR5XeMNxWUjDGGCCN2hQuPmQEp+w7mKxgXByse0bBSgrGGAOkUVDIzQw00/Nok/ttQcEYY4A0qj5qVn1JwaqPjDEGLCi437kWFIwxBtI+KBRBVk8IZqU6JcYY0ymkeVDYaO0JxhgTJ82DwiYLCsYYEyd9gkK4GtZ/3niZPc1sjDGNpE9Q+N9dcP8RDRPpgJUUjDGmifQJCoPHAdpQWghVQqjcSgrGGBMnfYLCIG847PUL3G97cM0YY7aRPkEhfwDkD4Z1TYKCPaNgjDH10icogKtCWjff/W1PMxtjzDaSGhREZJKILBWR5SJyfSvbnSkiKiITkpkeBo+H4uWusdkGwzPGmG0kLSiIiB+4BzgBGAucKyJjm9kuH7gGmJOstNQbFNfYXLEJxAe5BUk/rDHGdBXJLClMBJar6gpVDQFPAac1s90fgD8DNUlMi1M39/K6+a6kkFMAPn/SD2uMMV1FMoPCEGBN3OtCb1k9EdkfGKaq/21tRyIyRUTmici8oqKiHU9RXn/oMcT1QLJnFIwxZhspa2gWER9wO/DztrZV1QdUdYKqTujXr9/OHXjQONcDyZ5mNsaYbSQzKKwFhsW9Huotq5MP7A28KyIrgYOBaclvbB4Hxctg6zdWUjDGmCaSGRTmAqNEZKSIZADnANPqVqpqqaoWqOoIVR0BzAZOVdV5SUyT64EEUL3VSgrGGNNE0oKCqkaAq4A3gMXAM6q6UERuFpFTk3XcNtU92QxWUjDGmCaSOkezqk4HpjdZdmML2x6ZzLTUy+sHPYZCWaGVFIwxpon0eqK5Tl3XVCspGGNMI+kZFOqqkKykYIwxjSS1+qjTGncehCuh7+6pTokxxnQq6RkUeg6BY3+X6lQYY0ynk57VR8YYY5plQcEYY0w9CwrGGGPqWVAwxhhTz4KCMcaYehYUjDHG1LOgYIwxpp4FBWOMMfVEVVOdhu0iIkXAqh18ewGwuR2T01Wk43mn4zlDep53Op4zbP9576Kqbc5S1uWCws4QkXmqmtxJfDqhdDzvdDxnSM/zTsdzhuSdt1UfGWOMqWdBwRhjTL10CwoPpDoBKZKO552O5wzped7peM6QpPNOqzYFY4wxrUu3koIxxphWWFAwxhhTL22CgohMEpGlIrJcRK5PdXqSQUSGichMEVkkIgtF5BpveR8ReUtElnm/e6c6re1NRPwiMl9EXvVejxSROd71flpEMlKdxvYmIr1E5DkRWSIii0XkkDS51j/1vt9fisiTIpLV3a63iEwVkU0i8mXcsmavrTh3eef+uYjsvzPHTougICJ+4B7gBGAscK6IjE1tqpIiAvxcVccCBwM/9s7zeuBtVR0FvO297m6uARbHvf4z8HdV3R3YCvwgJalKrjuB11V1T2A/3Pl362stIkOAq4EJqro34AfOoftd70eASU2WtXRtTwBGeT9TgHt35sBpERSAicByVV2hqiHgKeC0FKep3anqelX91Pu7HHeTGII710e9zR4FTk9NCpNDRIYCJwEPeq8FOBp4ztukO55zT+AI4CEAVQ2pagnd/Fp7AkC2iASAHGA93ex6q+r7wJYmi1u6tqcB/1ZnNtBLRAbt6LHTJSgMAdbEvS70lnVbIjICGA/MAQao6npv1QZgQIqSlSx3AL8EYt7rvkCJqka8193xeo8EioCHvWqzB0Ukl25+rVV1LXAbsBoXDEqBT+j+1xtavrbten9Ll6CQVkQkD3geuFZVy+LXqeuD3G36IYvIycAmVf0k1WnpYAFgf+BeVR0PVNKkqqi7XWsArx79NFxQHAzksm01S7eXzGubLkFhLTAs7vVQb1m3IyJBXEB4XFVf8BZvrCtOer83pSp9SXAYcKqIrMRVCx6Nq2vv5VUvQPe83oVAoarO8V4/hwsS3flaAxwLfKOqRaoaBl7AfQe6+/WGlq9tu97f0iUozAVGeT0UMnANU9NSnKZ259WlPwQsVtXb41ZNAy72/r4YeLmj05YsqnqDqg5V1RG46/qOqp4PzAS+523Wrc4ZQFU3AGtEZLS36BhgEd34WntWAweLSI73fa877259vT0tXdtpwEVeL6SDgdK4aqbtljZPNIvIibi6Zz8wVVVvSXGS2p2IHA58AHxBQ/36r3HtCs8Aw3HDjk9W1aaNWF2eiBwJ/EJVTxaRXXElhz7AfOACVa1NZfram4iMwzWuZwArgEtxGb1ufa1F5PfA2bjedvOBH+Lq0LvN9RaRJ4EjccNjbwRuAl6imWvrBce7cdVoVcClqjpvh4+dLkHBGGNM29Kl+sgYY0wCLCgYY4ypZ0HBGGNMPQsKxhhj6llQMMYYU8+CgjEdSESOrBvJ1ZjOyIKCMcaYehYUjGmGiFwgIh+LyAIRud+br6FCRP7ujeX/toj087YdJyKzvbHsX4wb5353EZkhIp+JyKcispu3+7y4eRAe9x4+MqZTsKBgTBMiMgb3xOxhqjoOiALn4wZfm6eqewHv4Z4yBfg38CtV3Rf3NHnd8seBe1R1P+BQ3Kie4EavvRY3t8euuLF7jOkUAm1vYkzaOQY4AJjrZeKzcYOPxYCnvW3+A7zgzWvQS1Xf85Y/CjwrIvnAEFV9EUBVawC8/X2sqoXe6wXACODD5J+WMW2zoGDMtgR4VFVvaLRQ5LdNttvRMWLix+SJYv+HphOx6iNjtvU28D0R6Q/1c+Pugvt/qRuJ8zzgQ1UtBbaKyLe85RcC73kz3xWKyOnePjJFJKdDz8KYHWA5FGOaUNVFIvJ/wJsi4gPCwI9xE9lM9NZtwrU7gBvG+D7vpl83Wim4AHG/iNzs7eOsDjwNY3aIjZJqTIJEpEJV81KdDmOSyaqPjDHG1LOSgjHGmHpWUjDGGFPPgoIxxph6FhSMMcbUs6BgjDGmngUFY4wx9f4/zuy3grJ/hK8AAAAASUVORK5CYII=\n"
-            ],
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "needs_background": "light"
-          }
-        }
-      ],
-      "execution_count": null,
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "plt.plot(trained_model.history['loss'])\n",
-        "plt.plot(trained_model.history['val_loss'])\n",
-        "plt.title('model loss')\n",
-        "plt.ylabel('loss')\n",
-        "plt.xlabel('epoch')\n",
-        "plt.legend(['train', 'test'], loc='upper left')\n",
-        "\n",
-        "print(np.min(trained_model.history['loss']))\n",
-        "print(np.min(trained_model.history['val_loss']))"
-      ],
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "0.3663262344896793\n",
-            "0.7790719392895699\n"
-          ]
-        },
-        {
-          "output_type": "display_data",
-          "data": {
-            "image/png": [
-              "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3XeYVOX58PHvPbOzvbAsS9sFQQVFqoJdE9SoiDWxlyQmKprXJPpLYtQkxhYTjYktQREjlqgYYyUqgoViQQURld6kLHVZ2N5mZ+73j2e2sGyZXXZ2YOf+XBfX7JzzzDnPmTOc+zz1iKpijDHGAHiinQFjjDH7DgsKxhhj6lhQMMYYU8eCgjHGmDoWFIwxxtSxoGCMMaaOBQVjwiQiT4vIn8JMu05Evre32zGms1lQMMYYU8eCgjHGmDoWFEyXEqq2uUlEvhaRMhF5UkR6ich0ESkRkfdEJLNB+nNEZImIFIrIbBEZ0mDd4SKyMPS5/wCJjfZ1logsCn32ExEZ0c48XyMiq0Vkp4hME5G+oeUiIg+KyHYRKRaRb0RkWGjdeBFZGsrbJhH5Tbu+MGMasaBguqLzgVOBwcDZwHTgd0A27jf/SwARGQxMBW4MrXsb+J+IxItIPPA68G+gO/Df0HYJffZwYApwLZAFPA5ME5GEtmRURE4G/gJcBPQB1gMvhlafBnwndBwZoTQFoXVPAteqahowDPigLfs1pjkWFExX9A9V3aaqm4APgc9U9UtVrQReAw4PpbsYeEtV31VVP/A3IAk4DjgG8AEPqapfVV8G5jfYxwTgcVX9TFUDqvoMUBX6XFtcDkxR1YWqWgXcChwrIgMAP5AGHAqIqi5T1S2hz/mBw0QkXVV3qerCNu7XmCZZUDBd0bYGf1c08T419Hdf3J05AKoaBDYCOaF1m3T3GSPXN/j7AODXoaqjQhEpBPqFPtcWjfNQiisN5KjqB8A/gYnAdhGZLCLpoaTnA+OB9SIyR0SObeN+jWmSBQUTyzbjLu6Aq8PHXdg3AVuAnNCyWv0b/L0RuEdVuzX4l6yqU/cyDym46qhNAKr6iKqOBg7DVSPdFFo+X1XPBXriqrleauN+jWmSBQUTy14CzhSRU0TEB/waVwX0CTAPqAF+KSI+EfkBcFSDzz4BXCciR4cahFNE5EwRSWtjHqYCPxGRUaH2iD/jqrvWiciRoe37gDKgEgiG2jwuF5GMULVXMRDci+/BmDoWFEzMUtUVwBXAP4AduEbps1W1WlWrgR8AVwI7ce0Przb47ALgGlz1zi5gdShtW/PwHnAb8AqudHIQcElodTou+OzCVTEVAPeH1v0QWCcixcB1uLYJY/aa2EN2jDHG1LKSgjHGmDoWFIwxxtSxoGCMMaaOBQVjjDF14qKdgbbq0aOHDhgwINrZMMaY/coXX3yxQ1WzW0u33wWFAQMGsGDBgmhnwxhj9isisr71VFZ9ZIwxpgELCsYYY+pYUDDGGFNnv2tTaIrf7ycvL4/KyspoZyXiEhMTyc3NxefzRTsrxpguqEsEhby8PNLS0hgwYAC7T2rZtagqBQUF5OXlMXDgwGhnxxjTBXWJ6qPKykqysrK6dEAAEBGysrJiokRkjImOLhEUgC4fEGrFynEaY6KjywSFNlGFsh3u1RhjTJ3YDApVJVC0EapLO2RzhYWFPProo23+3Pjx4yksLOyQPBhjTEeIzaAQqA69+jtkc80FhZqamhY/9/bbb9OtW7cOyYMxxnSELtH7qM1qg0Gw5Yt2uG655RbWrFnDqFGj8Pl8JCYmkpmZyfLly1m5ciXnnXceGzdupLKykhtuuIEJEyYA9VN2lJaWcsYZZ3DCCSfwySefkJOTwxtvvEFSUlKH5M8YY8LV5YLCnf9bwtLNxS0nqql0AcFbDN41rW7zsL7p3H720GbX33vvvSxevJhFixYxe/ZszjzzTBYvXlzXbXTKlCl0796diooKjjzySM4//3yysrJ228aqVauYOnUqTzzxBBdddBGvvPIKV1xxResHbIwxHShi1UciMkVEtovI4mbWZ4jI/0TkKxFZIiI/iVRe9lDbwByhhuajjjpqt3EEjzzyCCNHjuSYY45h48aNrFq1ao/PDBw4kFGjRgEwevRo1q1bF5G8GWNMSyJZUnga91DzZ5tZfz2wVFXPFpFsYIWIPB96YHq7tXRHX2f7MldaSMyA7gfuze6alJKSUvf37Nmzee+995g3bx7JycmMHTu2yXEGCQkJdX97vV4qKio6PF/GGNOaiJUUVHUusLOlJECauI73qaG0HVPJ35oOblNIS0ujpKSkyXVFRUVkZmaSnJzM8uXL+fTTTztkn8YYEwnRbFP4JzAN2AykARerarCphCIyAZgA0L9//73bazAAGgj93TFBISsri+OPP55hw4aRlJREr1696taNGzeOSZMmMWTIEA455BCOOeaYDtmnMcZEgmgEB3CJyADgTVUd1sS6C4DjgV8BBwHvAiNVtcVW4jFjxmjjh+wsW7aMIUOGhJcpfyXkLwPxuvd9RoT3uX1Im47XGGMAEflCVce0li6a4xR+AryqzmrgW+DQiO+1doyCL8mVGGxUszHG1IlmUNgAnAIgIr2AQ4C1Ed9rMNSe4EsOve+cZgxjjNkfRKxNQUSmAmOBHiKSB9wO+ABUdRJwN/C0iHwDCHCzqu6IVH7q1DYy+0IDw4I14LVnExhjDEQwKKjqpa2s3wycFqn9NytQDZ64+kBgJQVjjKkTe3MfBfzg8bnAABYUjDGmgdgMCl4LCsYY05TYCwpBP3jj64NCYO+DQnunzgZ46KGHKC8v3+s8GGNMR4itoBAM1jcsi7ixCh1QUrCgYIzpKrrcLKktqu2OWtvI7InrkKDQcOrsU089lZ49e/LSSy9RVVXF97//fe68807Kysq46KKLyMvLIxAIcNttt7Ft2zY2b97MSSedRI8ePZg1a9Ze58UYY/ZG1wsK02+Brd80vU5rwF8BcUkuIPhDd+i1Yxaa03s4nHFvs6sbTp09c+ZMXn75ZT7//HNUlXPOOYe5c+eSn59P3759eeuttwA3J1JGRgYPPPAAs2bNokePHu05WmOM6VCxVX1UO3pZQoctgpuXr+PMnDmTmTNncvjhh3PEEUewfPlyVq1axfDhw3n33Xe5+eab+fDDD8nIyOjQ/RpjTEfoeiWFFu7oKdkGJZuh9wjweKFwA1QWuZJAB1FVbr31Vq699to91i1cuJC3336bP/zhD5xyyin88Y9/7LD9GmNMR4itkkLQ7xqXPaHJ8GrbFPZy/qOGU2effvrpTJkyhdLSUgA2bdrE9u3b2bx5M8nJyVxxxRXcdNNNLFy4cI/PGmNMtHW9kkJLAtW7T2lRN1YhAN72fxUNp84+44wzuOyyyzj22GMBSE1N5bnnnmP16tXcdNNNeDwefD4fjz32GAATJkxg3Lhx9O3b1xqajTFRF9GpsyNhr6bOzl/hSglZB7v35TuhcD1kDwFfYgRyGxk2dbYxpq32h6mzO1/tFBe1bFSzMcbsJnaCggbrRzPX8lpQMMaYhrpMUGi1Gqx2Oosm2xT8kclUBOxv1X3GmP1LlwgKiYmJFBQUtHzBbDyaGXZvaN4PqCoFBQUkJu4/7R/GmP1Ll+h9lJubS15eHvn5+c0n8pdD2Q7Y6dm9CqloB8RXQNKuyGe0AyQmJpKbmxvtbBhjuqguERR8Ph8DBw5sOVHhBvh2OQw6HhJS65c/cjn0GQkXPhXZTBpjzH4gYtVHIjJFRLaLyOIW0owVkUUiskRE5kQqLwB06w+HX757QABI6QHlkX8KqDHG7A8i2abwNDCuuZUi0g14FDhHVYcCF0YwL81L7gFlBVHZtTHG7GsiFhRUdS6ws4UklwGvquqGUPrtkcpLi1KyrKRgjDEh0ex9NBjIFJHZIvKFiPwoKrlI7gHlBXs9/5ExxnQF0WxojgNGA6cAScA8EflUVVc2TigiE4AJAP379+/YXKT0cIPXKgshKbNjt22MMfuZaJYU8oAZqlqmqjuAucDIphKq6mRVHaOqY7Kzszs2F8mhh9vUtivUVHXs9o0xZj8SzaDwBnCCiMSJSDJwNLAsUjubv24nVz+zgK1FlbuvSMlyr3Pvh8e/A3/qCStnRiobxhizT4tkl9SpwDzgEBHJE5GrROQ6EbkOQFWXAe8AXwOfA/9S1Wa7r+6tnWXVvLdsGztKG5UEMvq516//U/9Etp1rI5UNY4zZp0WsTUFVLw0jzf3A/ZHKQ0NpCe5Qy6oaTX6XfQhc9R50HwjxqXBPL6gu7YwsGWPMPqdLjGgOR2qiO9TSxkEBoN+R7lXVPZnNX96JOTPGmH1Hl5gQLxypCS0EhVoiEJ8C1WWdlCtjjNm3xE5QCJUUSipbeXaCBQVjTAyLmaCQluCmzG6xpADgS7agYIyJWTETFBJ9HrweoTSckoK1KRhjYlTMBAURITUhrvWSQnyqlRSMMTErZoICuMbm1tsUrPrIGBO7Yi4olFa18jxma2g2xsSw2AoKiWFUH/ksKBhjYldsBYWEOEqrAi0nik8BvwUFY0xsiq2gkBhHaWVr1UfWpmCMiV0xFRTSwu19FKiGQCvBwxhjuqCYCgqpCXGtj1PwJbtXKy0YY2JQbAWFxDjKqgMEgi08ejM+xb3aADZjTAyKraBQO312dQulhfhU92olBWNMDIqpoJBWO312S1VI8VZ9ZIyJXTEVFFLDmRSvtvrIgoIxJgbFVlAIZ/psnwUFY0zsiuQzmqeIyHYRafG5yyJypIjUiMgFkcpLrdQELxBmScEGsBljYlAkSwpPA+NaSiAiXuA+YGYE81Gntvpoj+c0N2RtCsaYGBaxoKCqc4GdrST7BfAKsD1S+WgoNayG5treR9Yl1RgTe6LWpiAiOcD3gcfCSDtBRBaIyIL8/Px277O2S2pJSyWFusFrpe3ejzHG7K+i2dD8EHCzqgZbS6iqk1V1jKqOyc7ObvcOa4NCiyUFXxIgNnjNGBOT4qK47zHAiyIC0AMYLyI1qvp6pHbo9QjJ8d6Wn6kgYk9fM8bErKgFBVUdWPu3iDwNvBnJgFArvEdy2kypxpjYFLGgICJTgbFADxHJA24HfACqOilS+21NamI4j+S0B+0YY2JTxIKCql7ahrRXRiofjYU1fbY9fc0YE6NiakQz1D5oJ4ySgg1eM8bEoJgLCinx1qZgjDHNibmgkJoYTlBIscFrxpiYFHNBwdoUjDGmeTEXFGrbFFRbefqatSkYY2JQ7AWFBB81QaWqpoWB1NYl1RgTo2IvKITzTIX4FKiphGCgk3JljDH7hpgLCmm18x/Z09eMMWYPMRcUwpsUz56pYIyJTbEXFGqrj1qaFK/2mQo2U6oxJsbEXlAIp6QQb89UMMbEppgLCmmJbWlTsJKCMSa2xFxQSAmnodlnDc3GmNgUc0EhtS29j2wAmzEmxsRcUEiI8+DzSphtChYUjDGxJeaCgoi0/vS12t5HFhSMMTEm5oIChPFMBRu8ZoyJUbEZFBJ8lLRUUohLcq8WFIwxMSZiQUFEpojIdhFZ3Mz6y0XkaxH5RkQ+EZGRkcpLY2kJrZQUPB7XA8kGrxljYkwkSwpPA+NaWP8t8F1VHQ7cDUyOYF52E96DdpJt8JoxJuZELCio6lxgZwvrP1HVXaG3nwK5kcpLY602NIM9fc0YE5P2lTaFq4Dpza0UkQkiskBEFuTn5+/1zlIT41qeOhvs6WvGmJgU9aAgIifhgsLNzaVR1cmqOkZVx2RnZ+/1Pt0jOVuYEA/s6WvGmJgU1aAgIiOAfwHnqmpBZ+03JSGOSn+QmkBLT19LtpKCMSbmRC0oiEh/4FXgh6q6sjP3XTvVRVlVC09Wi0+1NgVjTMyJi9SGRWQqMBboISJ5wO2AD0BVJwF/BLKAR0UEoEZVx0QqPw01fKZCRrKv6UTxKdb7yBgTcyIWFFT10lbWXw1cHan9tySsR3L6rPrIGBN7wqo+EpEbRCRdnCdFZKGInBbpzEVKbUmhuKKVqS5s8JoxJsaE26bwU1UtBk4DMoEfAvdGLFcR1icjEYAtRRXNJ6oNCsEWGqONMaaLCTcoSOh1PPBvVV3SYNl+J6ebmxo7b1crQQGstGCMiSnhBoUvRGQmLijMEJE0YL+9hU6K99IjNb7loOCzZyoYY2JPuA3NVwGjgLWqWi4i3YGfRC5bkZeTmUzerhZKAbXPVLABbMaYGBJuSeFYYIWqForIFcAfgKLIZSvycjOT2NRi9ZGVFIwxsSfcoPAYUB6a3vrXwBrg2YjlqhPkZiaRV1hBMKhNJ6h70I61KRhjYke4QaFGVRU4F/inqk4E0iKXrcjLzUymuibIjtKqphPUPZKz1JUWXrgElrzeeRk0xpgoCDcolIjIrbiuqG+JiIfQ6OT9VW6me7raxuaqkBo2NE/7BaycDl+92Em5M8aY6Ag3KFwMVOHGK2zFPfvg/ojlqhP0CwWFZhuba6uPPnkEFr8CyVmQ9zloM9VNxhjTBYQVFEKB4HkgQ0TOAipVdb9uU2h1rEJtUMibD0POgZN+D+UFsHNtJ+XQGGM6X7jTXFwEfA5cCFwEfCYiF0QyY5FWP1ahuZJCqE2hxyFw3qPQ72j3Pm9+52TQGGOiINxxCr8HjlTV7QAikg28B7wcqYx1BjdWoZmSQkIqnDcJBhwPCWnQcwjEp8HGz2HkJZ2bUWOM6SThBgVPbUAIKWAfeGrb3srNTGLp5uLmE4xqMNGrxws5R7h2BWOM6aLCvbC/IyIzRORKEbkSeAt4O3LZ6hy1A9iaHavQWL+jYdsSqLLnLBhjuqZwG5pvAiYDI0L/Jqtqs89U3l/kZiZTHQiS39xYhcb6HQUahM0LI5sxY4yJkrAfsqOqrwCvRDAvnS63QbfUXumJYXwg9GC4jZ/DwO9EMGfGGBMdLZYURKRERIqb+FciIi1UxoOITBGR7SKyuJn1IiKPiMhqEflaRI7YmwNpj/qxCi3MgdRQUib0GGw9kIwxXVaLQUFV01Q1vYl/aaqa3sq2nwbGtbD+DGBQ6N8E3PxKnSqs5yo0lnuUCwo2iM0Y0wVFrAeRqs4FdraQ5FzgWXU+BbqJSJ9I5acprY5VaEq/I20QmzGmy4pmt9IcYGOD93mhZXsQkQkiskBEFuTn53dsJloaq9CU3KPc60brmmqM6Xr2i7EGqjpZVceo6pjs7OwO3XZuZlLbgkL2oZCQAWtndWg+jDFmXxDNoLAJ6NfgfW5oWadq81gFj8cNavvmZatCMsZ0OdEMCtOAH4V6IR0DFKnqls7ORJvHKgCc8H/g9cHcv0UuY8YYEwURCwoiMhWYBxwiInkicpWIXCci14WSvA2sBVYDTwD/L1J5aUlua1NoNyWtN4y5yj1foWBNhHJmjIlJlcVR7d0Yyd5Hl6pqH1X1qWquqj6pqpNUdVJovarq9ap6kKoOV9UFkcpLSw7o7rqlrslv47OYT7gRvPEw568RyJUxJiYVbYK/DYJl/4taFvaLhuZIGpCVQnK8t+WJ8ZqS2hOOuhq+eQl2rIpM5owxsWXtLKiphHUfRS0LYU9z0VV5PMJhfdJZvKmo7R8+7gaY/yQ8djwkprtnMAy/AE7+Q8dn1BjT9a2d4163fh21LMR8SQFgWE4GS7cUEwi3B1Kt1Gy47CU4egIcepabBuOjh6BkW2QyaozpulTh27nu763fQDAYlWxYUACG9k2nvDrAuoI2tisADDwRTvsTnP0QnP8vCPph4TMdn0ljTNe2YyWUboXcI6G6NGpd3i0oAEP7ZgC0rwqpoayD4KBTYMEUCPg7IGfGmJhRW0o47hfudetXUcmGBQVgUK9U4r0elrS1sbkpR10DJVtg+Vt7v63GVGHlDPBXNp8mGIT/XAFfPt/x+zfGRM7a2ZDRHwafAR4fbIlOu4IFBcDn9XBonzSWbN7LkgLAoNOgW3/4/Im2fa50O3z8MARqmk+z6Hl44SKY98/m0yx/03VnW/Bk2/a/vwvUdO6YkYC/5XNl9k3lO+GBoVHt8tmkYMD1ODrwOxAXDz0PjVpjswWFkKF901m8qRjd20EjHq8b2Lb+I/foznC9ezu8+0dYNq3p9SXbYMbv3d8Ln2m6EUq1ftzEpoXuP0CsmPtX+OeYPe+uqkrg00lQU92x+3v+Avjvjzt2mwa+fsndHEXKsmlQnAefduJM/f4w5lbb+jVUFsLAse5975HutxyFQWwWFEKG9s2gqMLftsnxmnPEjyAuEebcF96FOX8FfP2i+/vzyU2needm8JfD2FuhcEPTE/KtmA7bvoExPwXUFUdjQVUpfPa4e1Tq+3fuvu7dP7rvbsmrHbe/LV+773blO7EVeCOtuhym/9bdIG1fHpl9fPOye13/cec05C78N/wl1/VKbKk3UW1X1IEnutc+I6F8BxRvjnweG7GgEDIsxzU2d0gVUnJ3OPJqWPoG/G0wvHg5fPth8+ln/wV8yW5OpQ3zYEujBqblb8OS1+C7v3VpkrPgi6d2T6PqglDmABh3LyRmwJoP9v5YImHXOqjsgO+51pf/dndZQ38Aq9+r/w+2cT4sCH1PX7+0+2dUYdV7UN2OHmfz/wXigWCNa+PpKFsXw9TLoCiv47a5P/lqKlTsAk+c+y13tJKtrorm8B+687doasfvoyFVd7MiXnjvdnju+y4PTfl2rpuBOa23e99nhHuNQhWSBYWQQ3un4fVIxzQ2A5x+D1z3ERx9rXtS23M/aPrOZMvX7oJ/zM/g+BtdcPisQWmhfCe89WvoOdQNlotLgFGXuVJBwx/YqndhyyI48TcuzcDvuqCwrz0h7otn4B+j4YHD4J1bXYDYGwE/zJsI/Y+F8x6DjH6udFBTDW/eCOl94ahr3Z196fb6z618B54/3323bVFRCN/8F0ZeBum5HVc3vWud+42seKs+kO3Lqkpg+s27f6d7Ixh0VTp9D3e9b5a8BtuXdcy2ay15DVA47pdw4EkuCEVyLMCWRa7kfvo9cPYjsOEzN9C1cMPu6Wqq3c1gw+e+9xoGSFQamy0ohCT6vBycnbr33VIb6j3c/SAmzHG9Cd79455pZt3j7uqP/TkkdYMRF7uLTlmB+4/3/AWuGHnuP1wDFMARV7q71EWhHkZlBfDB3a6Be+QlbtnBp0DxJtf3uTVVJW7OlUgKBuCd38H/fgkDToRDxruqskcOd3X+7bXkdSjaCMffAL5EOOn37j/j8xfAtsVwxl9hzE9AA6GLAi5QfvgAIO7CsPr98Pf31VRXjXfUNTDkLFjzvqu+2htlO+DfP3DTG/Qe7ko1nTFwaeN8mPdo+z775XPw2SQXkMPe3+dQuLHpdavfhYJVcMz1LijEp8Lse9uXt+YsfsV9v9mD3Y1V0UZYN7dj99HQwn+7auThF8LoH8OEWe63M/3mRumeccsPOqV+WUKq6+JuJYXoGpqTzuKOKik0lN4HTvw/d1fZsBpp7Rx3x3rcL11AAFeyCFS5/3AvXAKbF8GFz0DO6PrP9TjYXVi/eAYWveAaWLcvhVPvclN6Axx0sntt7YJXshUe/y48dqy7OLWVKuS3Enj8FfDiZfDpRHfXfvnLcP4TcMPX0P84mHOvq09uz74/fhh6DIZBp7tlIy5yd1nfznGBZ8hZ0HMI9BpeX4W0YR7kfQ6n3Q1Zg1yJIpwLu6qrOso9EvqOgiFnuwv56vfCz3PRJlev/cE9rlPAxw/Dc+e7AH7ZS3DsL6Bog8tjQyXb9iz1BYPw2s9gcTvbSz64C2bc6qonG9q13gWL5sbaqLqxOOCCQ00Y086X5sPTZ8HT410VUWPzJkJaXxh6nqt+PfpaWPp62zprtGTXOldiH3a+e3/oWe5hWYte6JjtN+avcOd5yDn1/7d7DoHv3gwr3q7vsr5jNcy8zQWEwafvvo0+I62kEG3D+maQX1LF9uIWxgG017E/d1UbM251d81LXnfdSzMHwtHX1afrOcQVI+f+1TWG/WAyHDp+z+2NvhIK18PrP4Osg+HaD2Ho9+vXd+vvLngttSuU7YBnz3WBoboM3r+r7cf16aMw8Uj46j9Nr68uhxcudnXv4/8G4/8K3tCUWxk5cNKt7iLxTaM6/4pCd2c34/fw1Jnw8lVuWUMr3nbF8+N+6R5+BK731/j73WNTz2hQLz38Ati0wHVb/egh1y4z5io45xFXnJ91T+vHunY2FKx27UXgqqySe+xeheSvdPtoeKefv8KVkh4cDg8eBq9c5c7vrHtc6TF/OVz4NPQ/xgUxX0p9xwNw1Q4PDNlzRt5l0+CrF1xQa2uDd1kBrPvY/f32TfVBsbIYnr/Q/U5fuarpbrfrPnQl0OEXulJsw+OvKoGXfrxnG9oXT7ubneLNLpA1/H62LnZB/Khr6m9qjr0eEtJh1p/bdlzNWfyKex36A/fqS4Th58PSaa59q6rUnbeO6qW2dBpUFblOJw0dez1kD3GlhcoieG2Cq+49dyKI7J629wh3g9DJnRksKDQwtG86AIs7orG5MV8SnHqnm9PkhYtdd8Y+I+Hq91xRsaHjbnDVTWc/7C5mTRlytqtqOvMB+OkM6HXYnmkOOtk1rDU12K18Jzx7nrsrvPwldwe/8FnXlTVc25fBe6HePnPu3fMCUl3mAt+3c119/1HX7LmNA453d/GfPV5/J+yvgCmnw8s/deM9/OWu0f7JU127jKq7s3zpRy7wjbio0TaPg6vfdYGx1vALAHGBb9UMOPpnEJ/s0o65ytVnb/i06eMMBt0xvH+XCyaHneeWe7wuYK+c4e6Wd62Hx0+EfxwB9/Z3wezJ02DiUa6qrM8IGHcfTJgNtxW4f7/bDDevg0POcNuMT4HDzoElb7jzVlPtqtw0AB8/BMVb6vM05z7XrlFV6jortMWKt902x//NddGc9We3zdd/5gLfET9y3/lr17qbmIYWTIHEbu73mTmgvtQA7vew9HWX59oLbE21K2Ed/D047R5YOR0+ecSt2/K163HkS3Y3OrWSu7tgv/xNd4FtqCjPlfqaai9rrg1t8avuRiHzgPplo66AmgrXGeQvOe68Tf9ty9/boqkukLfWUeLLf7sbvgEn7L7c64OzHnRVV5NPgk1fuCly0vvsuY0oNTZbUGhgaE4GXo/wxfomirf/kCxLAAAc90lEQVQdsoMfQL+jXf3psPPhR9Mgpcee6QZ9D27d6OohmxOX4EoRR15Vf5fc2MGnuB/9xkYXu4I18NR4d7d36Qvuhzv2ZkjJdncw4dRn11TDqxMgIc1dHHau3f1u31/hgl9taWfUpU1vRwSOuc5Vf9UO83/vzvq751vzXF3sj16Hsnx44hTXXjDjdzB4nAuqcQmt5zcj1wWgpa+7O/Ejr6pf97073MXixctccb5WoAY+/Ds8NByeOdtNkf69O91dZq0h50B1ibvIPXkqlG6D0//s2nZqKt0F+9S74FfL4JLn3bH2PdyVlrxxLgj4knbP64iL3V3myunwycPuuzjjr64dadafXJpl00JVhne6Lsjzn2xbN85l01zQPPJq9/nPHoPXr3MX4dP+BOf8w30vi1+GN66vr0oq2eZKBqMud3kf/RN3jrcvg/WfwPwnoN8x7vcw/1/1+yrd6krER1/rgur7d8GUcS6Ibl7kvqPk7rvn8YQb3Y3TmzfWN2iXbIWnz4RXr9lzEOeiqfDXA11DfW1wUIWPHnTtS41vsHKOgO/8Fo74sTvWQ8a76rDm2tcCNTDzD67K759HuuqhpoLQzrWuNHX4FXve/QMccKwLSDvXwPCLdi/hN9R7pHvtyB5u4VDV/erf6NGjNZLOm/iRfn/iR5HbQeFG1a9eUg0GI7ePWpUlqndmqT5zrur6T1UDAdXlb6v+OVf13gGqa2bvnn7hc6q3p6t++cKe29q1XnXOX1WXvKFamq/6/t0u7dJp7lgmnaj60EjVGr/798KlqrdnuGNtTXWF6n0DVV+4RHXNLLfdt27aM92O1aoPH656Z3fVTya2/Ttc8JTb9ju/a3rb9x2o+uAw1eKt7t+U8S79s+epfv1f1aqyPT/nr3Tf5+3pqg8MVd22rG15akqgRvVvh6g+/l3Vu7JV//Mjt/yd37nvdPNXqhOPUf3HGJe2dIfqX/qp/vsHTW/rk4mq86fUL6soVL2rR/33UL5L9f5B7hheuWb373X2X93yJ75X/xu4PV01f6VbX5rvtvXGz925eXC4alWp+839pb9qWYHq5JNVHznC/f5UVSuKVP9xpOrfDlX98EG3/+ZsW+a+g+cvVi3fqTrxWNU/9VF96kzVO7qprv7ApVs+XfWOTPc93J6u+trP3L7/+1P3/qUr3e+sJTvXuW1Mv6Xp9avec9ua9Rd3bm5PV33uAvcd1Crf6X43d2SqFm1qfl/lO1Xn/t2di5a8fr3b1qYvW04XBmCBhnGNFd3Xuiy2YsyYMbpgQeQe0nb/jOVMmrOWr24/jdSELvC4iVl/dnXogSpI6+PmZeozEi5+bvfqFXAlhNoqmh//D3oPc8tLt7vljbuPjrwMvh8aGbpiOky9xNWN5s13dchn3O+mFQ/H+3e7u/LUnq4u+dq5rnqnsapSKC/YvRogXNVlrkfL8Tc0XULb9IVrDO12AFTsdPXrZz9U36OrOTNvg7wFcMGUpqsB2mPmba70kZABP//c9V+v2AUPj3Ili5ItcP6T9Xe/8x517QBnPQQjL3WlmaI8V5pb/zEg8JPp7i716//Cq1fDT2dC/6Pd59fOdne+4+/fs+TyzcvwvxtdidQb79q9ftygHeGVq12POYAfvQEHjnXtBJNOcO1j387Z87cQ8LuxAh5v69/FvImuZJie60pil//XNfb/63vu/Rl/hWm/gOxD4MfTXPo594E3AQLVcMptcMKvmr5rb+y161y12Y2LISVr93WvX+/W3bTaVQN9/oSrSkrOcqXa9D6uPaZgjasuHXFh6/trTcUu+OdR7vxfM6u+Pa4dROQLVR3TasJwIkd7/wHjgBW45zDf0sT6/sAs4Evga2B8a9uMdEnho1X5esDNb+oHy7ZFdD+dqqJIddFUd/c+/RbV6vLm0+avUv37EHfHteEz1cpiVwr4U2/VdR+7Esfcv6v+78bd73KCQXf3dHdPdwf17h1ty2PRZlcCuCNTNW9Be46yY6x81+XjkSNUty6JXj62LXP5+OKZ3Zd/8k/3/daWEmr5q1QfPd6tu6ev6tTL3Dm8p68rJTw4XPXhUe4u/sXLVe8fXH/nHo4dq1Unfcdtf/Fru69b94lb/sYvdl/++vVu+Z9z3e+ovQKBUKktY/d971it+udQyeDhw3e/Y18xQ/Xxsa5k3Bbblrntvf+n3Zf7K92+Xr129+WbF7kS8p3dXWn3z/1U185p2z5bs/g1l6ePHtqrzRBmSSGSAcELrAEOBOKBr4DDGqWZDPws9PdhwLrWthvpoFBRXaODfve23vPW0ojuZ5+2a727gPypt/uPdUem6sqZrX9uxQz34331uvZVj302WXXRi23/XEfbsdpdPKOtqaoFf6Xqf36ouurdptetfFd12i9d9dOT41QL1rh1334YunD/XPXuXqpv/qrt+fFXqn77UdPnds3sPatnire4gDDj923fV2OVxapbvtlz+ar3VJ8+21X9dJTagNowkC17031/K5v43isKVV/6sQtM2yJw3QgGXZ7u7ul+m+0UblCIWPWRiBwL3KGqp4fe3xoqmfylQZrHgbWqel8o/d9V9biWthvp6iOAix+fR1l1DW/+4sSI7mefVrLNjbDdthjOm9R8Q3Fj25e5cQPhVAuYzjX9Zjf+BVwnhwO/G/l9lu90nRFqu5ruDzZ9AU+c7MYUnPQ7t+zln7oqtl+vaP5YVMOromqP4s0w8WjX0+7Mv7drE+FWH0Wy0jwHaDh8MQ84ulGaO4CZIvILIAX4XlMbEpEJwASA/v37N5WkQx13UA8een8lheXVdEuOj/j+9klpveCn77juiX0PD/9zPYdELk9m75zyR9eTparY9cTqDI17FO0Pcka73oFz7nM9246+zrWZjbyk5eAWqYAAbrqWK9/qlP9f0e6SeinwtKrmAuOBf4vIHnlS1cmqOkZVx2RnZ0c8U8cdnIUqfPZtjM+AmZDWtoBg9m3xKa4h+Iev7VWDZUz4/uOuu+j7d7kpSPzlMKyZMUOdpc+ITilxRTIobAL6NXifG1rW0FXASwCqOg9IBJroFtK5RuZ2I8nnZd6agmhnxZiOlXmA631mWub1ucBw1AQ3zietrxvBHgMiebswHxgkIgNxweAS4LJGaTYApwBPi8gQXFDIj2CewhIf52HMgEw+WdOOuYCMMV2Dx+O6u2Yf6rpzNzdItIuJ2FGqag3wc2AGsAx4SVWXiMhdInJOKNmvgWtE5CtgKnClRqrlu42OO6gHK7eVkl8SxmRfxpiuScSNfm9q/rEuKqIVi6r6NvB2o2V/bPD3UqCTWrza5tiD3MCVeWsLOGdk3yjnxhhjOkdslIfaYVjfdLol+/hg2bZoZ8UYYzqNBYVmxHk9nDqkF+8v205VTaD1DxhjTBdgQaEFZwzvTUlVDZ+stl5IxpjYYEGhBccf3IO0hDjeWdzMw7aNMaaLsaDQgoQ4LycP6cnMpVupCXTCM3ONMSbKLCi04oxhvdlV7ufzWB/dbIyJCRYUWvHdwT1J8nmZblVIxpgYYEGhFUnxXsYeks2MJVsJBveJcXXGGBMxFhTCMG5Yb7aXVLFwQ4Se3WyMMfsICwphOPnQnsTHeXj1y2Ye6G2MMV2EBYUwpCX6OP+IHF7+Io/tJZXRzo4xxkSMBYUwXfudg6gJBHnyo2+jnRVjjIkYCwphGtAjhbNG9OW5eespKvdHOzvGGBMRFhTa4GdjD6KsOsAz89ZFOyvGGBMRFhTaYEifdE45tCdPffwt5dU10c6OMcZ0OAsKbfT/TjqYXeV+XvhsQ7SzYowxHc6CQhuNPiCT4w7KYtKctVZaMMZ0ORYU2uFXpw5mR2kVz85bH+2sGGNMh4poUBCRcSKyQkRWi8gtzaS5SESWisgSEXkhkvnpKGMGdOe7g7N5fM4aSqustGCM6ToiFhRExAtMBM4ADgMuFZHDGqUZBNwKHK+qQ4EbI5Wfjvbr0wazq9zPUzZuwRjThUSypHAUsFpV16pqNfAicG6jNNcAE1V1F4Cqbo9gfjrUiNxunHpYLyZ/uNbGLRhjuoxIBoUcYGOD93mhZQ0NBgaLyMci8qmIjGtqQyIyQUQWiMiC/Pz8CGW37X516mBKKmt4dM7qaGfFGGM6RLQbmuOAQcBY4FLgCRHp1jiRqk5W1TGqOiY7O7uTs9i8IX3SuWhMLpPnrmXuyn0nWBljTHtFMihsAvo1eJ8bWtZQHjBNVf2q+i2wEhck9ht3nDOUwT3TuOHFL8nbVR7t7BhjzF6JZFCYDwwSkYEiEg9cAkxrlOZ1XCkBEemBq05aG8E8dbjk+Dgm/XA0NQHl+ucXUlUTiHaWjDGm3SIWFFS1Bvg5MANYBrykqktE5C4ROSeUbAZQICJLgVnATapaEKk8RcrAHincf+FIvsor4q7/LY12dowxpt1Edf96xOSYMWN0wYIF0c5Gk/7y9jIen7uWiZcdwZkj+kQ7O8YYU0dEvlDVMa2li3ZDc5fym9MPYVS/btzy6tds3GntC8aY/Y8FhQ7k83r4x6WHg8Ivpn6JPxCMdpaMMaZNLCh0sH7dk7n3/BEs2ljIX95ezv5WPWeMiW1x0c5AV3TmiD58/u0BTPn4W4or/fz5+8OJj7P4a4zZ91lQiJA7zhlKt+R4Hn5/FRt3ljPpitFkpsRHO1vGGNMiu32NEBHh/04dzMOXjOLLDYWc9+jHLN5UFO1sGWNMiywoRNi5o3KYOuEYqvxBfvDoJ/z70/XWzmCM2WdZUOgEow/I5O0bTuTYg7K47fXF/Oy5hWwosC6rxph9jwWFTtI9JZ6nrjyS3447hFkrtnPy32fzu9e+YUtRRbSzZowxdSwodCKPR/h/Yw9m7m9P4rKj+/PfBRsZe/9sJs1ZY2MajDH7BAsKUdArPZG7zh3GB78ey9hDsrl3+nLO+efHfLWxMNpZM8bEOJv7aB/wzuKt3D5tMduKqxjSJ53TDuvF94b04uCeqSTFe6OdPWNMFxDu3EcWFPYRxZV+Xpq/kZlLtjF//U5qT0uP1AQG9kjmh8cO4KzhffB4JLoZNcbslywo7Md2lFbxyZoCNhSUsXFnBQs37GLV9lKG5aTzm9MOoW+3JIor/JRVBxjVrxsZSb5oZ9kYs48LNyjYiOZ9UI/UBM4Z2bfufTCovPHVJv42YyVXPjV/t7RJPi/nj87hyuMGcnDP1M7OqjGmi7GSwn6k0h/gvWXbUIX0JB9eEV5ftIlpizZTHQgS5xGCqigwtG86543K4ZyRfemZnhjtrBtjosyqj2LIjtIqXv9yE7vKqxGEgCofr97B13lFeAQOzE6ld3oivdITGZCVzKF90hnSJ42cbkmIWBuFMbFgn6g+EpFxwMOAF/iXqt7bTLrzgZeBI1XVrvht1CM1gatPPHCP5au3lzLtq82s3FrC1uJKVq/ewSsLK+vWez1CcryX1IQ4eqYlcHj/TI44IJOBWSmUVPoprPDjDwTpmZZITrckeqYnkBDnsUBiTBcWsZKCiHiBlcCpQB4wH7hUVZc2SpcGvAXEAz9vLShYSWHvlFbVsGJrMUu3lLC1qIKyqgDl1TVs2FnOVxuLqPAHWvy8CCTEeUiOj6N3eiI5mUn0y0zm0D5pDO2bzqCeaTZNuDH7oH2hpHAUsFpV14Yy9CJwLtD4yfZ3A/cBN0UwLyYkNSGO0Qd0Z/QB3fdYVxMIsnxrCZsLK0hP8tEt2UecR9haVMXmogryS6qo8geoqglSUlXDlsIK1heU8dGqHXXBpLb0kejzEu/1oKpUB5SaYJBgUFGFoCoZST56ZSTSJyORPhlJ9O2WRE63RHqmJ5KVEk/3lHhKKmtYvKmIJZuL8XqEs0b04cBsa0w3JpIiGRRygI0N3ucBRzdMICJHAP1U9S0RaTYoiMgEYAJA//79I5BVAxDn9TAsJ4NhORm7LT+4Z1qLnwsGlXUFZSzeXMzKrSWUVtVQVROkqiaAV4Q4rwefV/CI+wdQWFHNtuJKVmwtYdby/BZLKB4BBR54dyUjcjM4akB3yqprKCz3A65RfURut7reV4Gg4g8EqQ4E8dcoVTUBSqpqKK2socIfoE9GIgOyUujbLQlvG8Z91JaqrfrMdGVR65IqIh7gAeDK1tKq6mRgMrjqo8jmzLSVxyMcmJ3q7uJHtv3zqkphuZ9Nha40UlBWzc6yKpJ8Xg7rm8GQPmkUV9Twv6828/qiTTz76XoyknxkJPnwB4JMX7y1XfmO93rITkugR1oC2anxddVeqlBeHaCowk9xhZ/SqhrKqmoo9wfISPIxqGcqB/dMo2daAj6vC3rpiT5yM5PIzUwiKzUBr0fwiuDxgM/jqRt0WBMIUuEP4A8oiT4PiXHeZgckBoKKRywImc4VyaCwCejX4H1uaFmtNGAYMDv0o+8NTBORc6yxObaICJkp8S0+mS45Po5rvnMg13xnzwb1ogo/izcVsa6gDK8IXo/g83qIj/Pg83pIiPOQmhhHWkIcCXFeNhVWsK6gjHUFZeQXV5FfWsWmwkpqQpMSKpAS7yU9yUdOZhLpiXEkx8eRHO+loKya1dtKmb54S11JJRxejyBATXDPe5qEOJfXhDgPXo9Q6Q9SXl2DP6CuOs7nJTHeW5cu3ush0eclyecl0echKd5Lki+OpHgPu8r9bCgoZ8POcuLjPBzaO41De6eRkhDH1qJKthRV4vN6OObA7hx3UA9yMpNYvb2UldtK3DqPEB/nttkrPZG+GUl0S/axvaSKLaEqRH8gSO38jf26JzGoZxoDeiTjFaGyJkilP0BqQhyJvr2bosVVPQYprwpQVl0DQM+0RGuzirBINjTH4RqaT8EFg/nAZaq6pJn0s4HfWEOz2V8Eg4o/GCQQVHaV+8nbWU7ergp2lVcTVCWo9VVZNQElqEqSz0tSvJc4j7uAVlQHqAy109SmS/R5SE6IIzHOS3UgQHl1gIrqANU1QaoCQar8rmqu0h+gwh+g0u+2U+EPkJ4YR/+sFPplJlHpD7J8azGrtpdSXROkR2oCfTISKan0s64TnueR6POQmRyPKlT46/OX0y2JnMwkAkFla3EVW4sqqKgOEB/nAl9Q1ZXMqgNNBtGslHiy0xLqAqMvzoM/VF0ZCCrJ8XGkJMSRFO+lrKqmrrSXkeSjd0Yi2akJ7CyrJm9XBZsKK8hKjWdQzzQG90rFHwjWLU9NiGNwrzQO6Z2G1yN1wXZnWTWV/gCVNQES4rwckJXMgKwUemckEu/1EOd1pcSAKjVBrWtLA3dTUBrKU4U/QFZKPL3SE+mZnkCfjCQyk32ICCWVfr7aWMQ3m4pITYxjQGgffTISifO2LyhGvaFZVWtE5OfADFyX1CmqukRE7gIWqOq0SO3bmM7g8QgJHnc3nBzvLnZHt/KZaKgJBAkqu91hbymq4JPVBeSXVjGoZyqDe7lxK8HQ3XlZVSBUsqigsNxPdloCfbol1t2p11701heUsXp7Ket2lCPiRtgn+DyUVrk2n11l1XhESIp3y4sr/OTtqmD5lhI8HqFPRiKDe2aTHO+lOuACqAApCa5klhzvJSUhjpT4OIKqbCuuYmtxJTtKq9yF2R+gvCJAgtf1iPN6hIrqAJsKK6ioriElIY6MJB/9UpIpLK9m4YZd5JdUkZkcT7/MZI4ckMmO0mrmrsrnlYV5APRIjadvtyTydlXwzpKtNLxvTkuMcwEpzpXSCkqr+XRtAeXVLffaC1dCnIeslHi2FFfS1P36T44fwO1nD+2QfTXHBq8ZYwxQVO6vqzqrVVEdYPX2UhTlgO4pZCTvOc+YqpJfWsX24ipqQiXDQFCJ8wieUNuSCAjuNT3RR1qiq17bWe46XGwLVe1tLa4kv6SKAVkpHHFAN0bkdKPCH2BdQRnrC8o4uGcaow/IbNfx2YhmY4wxdcINCtZiY4wxpo4FBWOMMXUsKBhjjKljQcEYY0wdCwrGGGPqWFAwxhhTx4KCMcaYOhYUjDHG1NnvBq+JSD6wvp0f7wHs6MDs7C9i8bhj8ZghNo87Fo8Z2n7cB6hqdmuJ9rugsDdEZEE4I/q6mlg87lg8ZojN447FY4bIHbdVHxljjKljQcEYY0ydWAsKk6OdgSiJxeOOxWOG2DzuWDxmiNBxx1SbgjHGmJbFWknBGGNMCywoGGOMqRMzQUFExonIChFZLSK3RDs/kSAi/URklogsFZElInJDaHl3EXlXRFaFXtv36KZ9nIh4ReRLEXkz9H6giHwWOuf/EZH4aOexI4lINxF5WUSWi8gyETk2Fs61iPxf6Pe9WESmikhiVzzXIjJFRLaLyOIGy5o8v+I8Ejr+r0XkiPbuNyaCgoh4gYnAGcBhwKUiclh0cxURNcCvVfUw4Bjg+tBx3gK8r6qDgPdD77uiG4BlDd7fBzyoqgcDu4CropKryHkYeEdVDwVG4o69S59rEckBfgmMUdVhuOe/X0LXPNdPA+MaLWvu/J4BDAr9mwA81t6dxkRQAI4CVqvqWlWtBl4Ezo1ynjqcqm5R1YWhv0twF4kc3LE+E0r2DHBedHIYOSKSC5wJ/Cv0XoCTgZdDSbrUcYtIBvAd4EkAVa1W1UJi4FwDcUCSiMQBycAWuuC5VtW5wM5Gi5s7v+cCz6rzKdBNRPq0Z7+xEhRygI0N3ueFlnVZIjIAOBz4DOilqltCq7YCvaKUrUh6CPgtEAy9zwIKVbUm9L6rnfOBQD7wVKjK7F8ikkIXP9equgn4G7ABFwyKgC/o2ue6oebOb4dd42IlKMQUEUkFXgFuVNXihuvU9UHuUv2QReQsYLuqfhHtvHSiOOAI4DFVPRwoo1FVURc915m4u+KBQF8ghT2rWGJCpM5vrASFTUC/Bu9zQ8u6HBHx4QLC86r6amjxttqiZOh1e7TyFyHHA+eIyDpc1eDJuPr2bqEqBuh65zwPyFPVz0LvX8YFia5+rr8HfKuq+arqB17Fnf+ufK4bau78dtg1LlaCwnxgUKiHQjyuYWpalPPU4UL16E8Cy1T1gQarpgE/Dv39Y+CNzs5bJKnqraqaq6oDcOf2A1W9HJgFXBBK1qWOW1W3AhtF5JDQolOApXTxc42rNjpGRJJDv/fa4+6y57qR5s7vNOBHoV5IxwBFDaqZ2iRmRjSLyHhcvbMXmKKq90Q5Sx1ORE4APgS+ob5u/Xe4doWXgP64accvUtXGDVhdgoiMBX6jqmeJyIG4kkN34EvgClWtimb+OpKIjMI1rMcDa4Gf4G70uvS5FpE7gYtxve2+BK7G1Z93qXMtIlOBsbgpsrcBtwOv08T5DQXIf+Kq0sqBn6jqgnbtN1aCgjHGmNbFSvWRMcaYMFhQMMYYU8eCgjHGmDoWFIwxxtSxoGCMMaaOBQVjOpGIjK2dxdWYfZEFBWOMMXUsKBjTBBG5QkQ+F5FFIvJ46FkNpSLyYGgu//dFJDuUdpSIfBqax/61BnPcHywi74nIVyKyUEQOCm0+tcFzEJ4PDTwyZp9gQcGYRkRkCG7E7PGqOgoIAJfjJl9boKpDgTm4EaYAzwI3q+oI3Gjy2uXPAxNVdSRwHG5WT3Cz196Ie7bHgbi5e4zZJ8S1nsSYmHMKMBqYH7qJT8JNPBYE/hNK8xzwaui5Bt1UdU5o+TPAf0UkDchR1dcAVLUSILS9z1U1L/R+ETAA+Cjyh2VM6ywoGLMnAZ5R1Vt3WyhyW6N07Z0jpuGcPAHs/6HZh1j1kTF7eh+4QER6Qt1zcQ/A/X+pnYnzMuAjVS0CdonIiaHlPwTmhJ58lyci54W2kSAiyZ16FMa0g92hGNOIqi4VkT8AM0XEA/iB63EPsjkqtG47rt0B3BTGk0IX/drZSsEFiMdF5K7QNi7sxMMwpl1sllRjwiQipaqaGu18GBNJVn1kjDGmjpUUjDHG1LGSgjHGmDoWFIwxxtSxoGCMMaaOBQVjjDF1LCgYY4yp8/8BI4VFHAnikZoAAAAASUVORK5CYII=\n"
-            ],
-            "text/plain": [
-              "<Figure size 432x288 with 1 Axes>"
-            ]
-          },
-          "metadata": {
-            "needs_background": "light"
-          }
-        }
-      ],
-      "execution_count": null,
-      "metadata": {}
-    }
-  ],
-  "metadata": {
-    "kernel_info": {
-      "name": "python3"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "language": "python",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.7.3",
-      "mimetype": "text/x-python",
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "pygments_lexer": "ipython3",
-      "nbconvert_exporter": "python",
-      "file_extension": ".py"
-    },
-    "nteract": {
-      "version": "0.14.3"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BinaryNet on CIFAR10\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/larq/docs/blob/master/docs/larq/tutorials/binarynet_cifar10.ipynb\"><button class=\"notebook-badge\">Run on Colab</button></a> <a href=\"https://github.com/larq/docs/blob/master/docs/larq/tutorials/binarynet_cifar10.ipynb\"><button class=\"notebook-badge\">View on GitHub</button></a>\n",
+    "\n",
+    "In this example we demonstrate how to use Larq to build and train BinaryNet on the CIFAR10 dataset to achieve a validation accuracy approximately 83% on laptop hardware.\n",
+    "On a Nvidia GTX 1050 Ti Max-Q it takes approximately 200 minutes to train. For simplicity, compared to the original papers [BinaryConnect: Training Deep Neural Networks with binary weights during propagations](https://arxiv.org/abs/1511.00363), and [Binarized Neural Networks: Training Deep Neural Networks with Weights and Activations Constrained to +1 or -1](https://arxiv.org/abs/1602.02830), we do not impliment learning rate scaling, or image whitening."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 2
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install larq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "import larq as lq\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import CIFAR10 Dataset\n",
+    "\n",
+    "We download and normalize the CIFAR10 dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Downloading data from https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz\n",
+      "170500096/170498071 [==============================] - 38s 0us/step\n"
+     ]
+    }
+   ],
+   "source": [
+    "num_classes = 10\n",
+    "\n",
+    "(train_images, train_labels), (test_images, test_labels) = tf.keras.datasets.cifar10.load_data()\n",
+    "\n",
+    "train_images = train_images.reshape((50000, 32, 32, 3)).astype(\"float32\")\n",
+    "test_images = test_images.reshape((10000, 32, 32, 3)).astype(\"float32\")\n",
+    "\n",
+    "# Normalize pixel values to be between -1 and 1\n",
+    "train_images, test_images = train_images / 127.5 - 1, test_images / 127.5 - 1\n",
+    "\n",
+    "train_labels = tf.keras.utils.to_categorical(train_labels, num_classes)\n",
+    "test_labels = tf.keras.utils.to_categorical(test_labels, num_classes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build BinaryNet\n",
+    "\n",
+    "Here we build the BinaryNet model layer by layer using the [Keras Sequential API](https://www.tensorflow.org/guide/keras)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# All quantized layers except the first will use the same options\n",
+    "kwargs = dict(input_quantizer=\"ste_sign\",\n",
+    "              kernel_quantizer=\"ste_sign\",\n",
+    "              kernel_constraint=\"weight_clip\",\n",
+    "              use_bias=False)\n",
+    "\n",
+    "model = tf.keras.models.Sequential([\n",
+    "    # In the first layer we only quantize the weights and not the input\n",
+    "    lq.layers.QuantConv2D(128, 3,\n",
+    "                          kernel_quantizer=\"ste_sign\",\n",
+    "                          kernel_constraint=\"weight_clip\",\n",
+    "                          use_bias=False,\n",
+    "                          input_shape=(32, 32, 3)),\n",
+    "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
+    "\n",
+    "    lq.layers.QuantConv2D(128, 3, padding=\"same\", **kwargs),\n",
+    "    tf.keras.layers.MaxPool2D(pool_size=(2, 2), strides=(2, 2)),\n",
+    "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
+    "\n",
+    "    lq.layers.QuantConv2D(256, 3, padding=\"same\", **kwargs),\n",
+    "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
+    "\n",
+    "    lq.layers.QuantConv2D(256, 3, padding=\"same\", **kwargs),\n",
+    "    tf.keras.layers.MaxPool2D(pool_size=(2, 2), strides=(2, 2)),\n",
+    "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
+    "\n",
+    "    lq.layers.QuantConv2D(512, 3, padding=\"same\", **kwargs),\n",
+    "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
+    "\n",
+    "    lq.layers.QuantConv2D(512, 3, padding=\"same\", **kwargs),\n",
+    "    tf.keras.layers.MaxPool2D(pool_size=(2, 2), strides=(2, 2)),\n",
+    "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
+    "    tf.keras.layers.Flatten(),\n",
+    "\n",
+    "    lq.layers.QuantDense(1024, **kwargs),\n",
+    "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
+    "\n",
+    "    lq.layers.QuantDense(1024, **kwargs),\n",
+    "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
+    "\n",
+    "    lq.layers.QuantDense(10, **kwargs),\n",
+    "    tf.keras.layers.BatchNormalization(momentum=0.999, scale=False),\n",
+    "    tf.keras.layers.Activation(\"softmax\")\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One can output a summary of the model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "+sequential stats---------------------------------------------------------------------------------------------+\n",
+      "| Layer                  Input prec.            Outputs   # 1-bit  # 32-bit   Memory  1-bit MACs  32-bit MACs |\n",
+      "|                              (bit)                          x 1       x 1     (kB)                          |\n",
+      "+-------------------------------------------------------------------------------------------------------------+\n",
+      "| quant_conv2d                     -  (-1, 30, 30, 128)      3456         0     0.42           0      3110400 |\n",
+      "| batch_normalization              -  (-1, 30, 30, 128)         0       256     1.00           0            0 |\n",
+      "| quant_conv2d_1                   1  (-1, 30, 30, 128)    147456         0    18.00   132710400            0 |\n",
+      "| max_pooling2d                    -  (-1, 15, 15, 128)         0         0        0           0            0 |\n",
+      "| batch_normalization_1            -  (-1, 15, 15, 128)         0       256     1.00           0            0 |\n",
+      "| quant_conv2d_2                   1  (-1, 15, 15, 256)    294912         0    36.00    66355200            0 |\n",
+      "| batch_normalization_2            -  (-1, 15, 15, 256)         0       512     2.00           0            0 |\n",
+      "| quant_conv2d_3                   1  (-1, 15, 15, 256)    589824         0    72.00   132710400            0 |\n",
+      "| max_pooling2d_1                  -    (-1, 7, 7, 256)         0         0        0           0            0 |\n",
+      "| batch_normalization_3            -    (-1, 7, 7, 256)         0       512     2.00           0            0 |\n",
+      "| quant_conv2d_4                   1    (-1, 7, 7, 512)   1179648         0   144.00    57802752            0 |\n",
+      "| batch_normalization_4            -    (-1, 7, 7, 512)         0      1024     4.00           0            0 |\n",
+      "| quant_conv2d_5                   1    (-1, 7, 7, 512)   2359296         0   288.00   115605504            0 |\n",
+      "| max_pooling2d_2                  -    (-1, 3, 3, 512)         0         0        0           0            0 |\n",
+      "| batch_normalization_5            -    (-1, 3, 3, 512)         0      1024     4.00           0            0 |\n",
+      "| flatten                          -         (-1, 4608)         0         0        0           0            0 |\n",
+      "| quant_dense                      1         (-1, 1024)   4718592         0   576.00     4718592            0 |\n",
+      "| batch_normalization_6            -         (-1, 1024)         0      2048     8.00           0            0 |\n",
+      "| quant_dense_1                    1         (-1, 1024)   1048576         0   128.00     1048576            0 |\n",
+      "| batch_normalization_7            -         (-1, 1024)         0      2048     8.00           0            0 |\n",
+      "| quant_dense_2                    1           (-1, 10)     10240         0     1.25       10240            0 |\n",
+      "| batch_normalization_8            -           (-1, 10)         0        20     0.08           0            0 |\n",
+      "| activation                       -           (-1, 10)         0         0        0           ?            ? |\n",
+      "+-------------------------------------------------------------------------------------------------------------+\n",
+      "| Total                                                  10352000      7700  1293.75   510961664      3110400 |\n",
+      "+-------------------------------------------------------------------------------------------------------------+\n",
+      "+sequential summary---------------------------+\n",
+      "| Total params                      10.4 M    |\n",
+      "| Trainable params                  10.4 M    |\n",
+      "| Non-trainable params              7.7 k     |\n",
+      "| Model size                        1.26 MiB  |\n",
+      "| Model size (8-bit FP weights)     1.24 MiB  |\n",
+      "| Float-32 Equivalent               39.52 MiB |\n",
+      "| Compression Ratio of Memory       0.03      |\n",
+      "| Number of MACs                    514 M     |\n",
+      "| Ratio of MACs that are binarized  0.9939    |\n",
+      "+---------------------------------------------+\n"
+     ]
+    }
+   ],
+   "source": [
+    "lq.models.summary(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model Training\n",
+    "\n",
+    "Compile the model and train the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "model.compile(\n",
+    "    tf.keras.optimizers.Adam(lr=0.01, decay=0.0001),\n",
+    "    loss=\"categorical_crossentropy\",\n",
+    "    metrics=[\"accuracy\"],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "outputExpanded": true,
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Train on 50000 samples, validate on 10000 samples\n",
+      "Epoch 1/100\n",
+      "50000/50000 [==============================] - 131s 3ms/step - loss: 1.5733 - acc: 0.4533 - val_loss: 1.6368 - val_acc: 0.4244\n",
+      "Epoch 2/100\n",
+      "50000/50000 [==============================] - 125s 3ms/step - loss: 1.1485 - acc: 0.6387 - val_loss: 1.8497 - val_acc: 0.3764\n",
+      "Epoch 3/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.9641 - acc: 0.7207 - val_loss: 1.5696 - val_acc: 0.4794\n",
+      "Epoch 4/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.8452 - acc: 0.7728 - val_loss: 1.5765 - val_acc: 0.4669\n",
+      "Epoch 5/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.7553 - acc: 0.8114 - val_loss: 1.0653 - val_acc: 0.6928\n",
+      "Epoch 6/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.6841 - acc: 0.8447 - val_loss: 1.0944 - val_acc: 0.6880\n",
+      "Epoch 7/100\n",
+      "50000/50000 [==============================] - 125s 3ms/step - loss: 0.6356 - acc: 0.8685 - val_loss: 0.9909 - val_acc: 0.7317\n",
+      "Epoch 8/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.5907 - acc: 0.8910 - val_loss: 0.9453 - val_acc: 0.7446\n",
+      "Epoch 9/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.5610 - acc: 0.9043 - val_loss: 0.9441 - val_acc: 0.7460\n",
+      "Epoch 10/100\n",
+      "50000/50000 [==============================] - 125s 3ms/step - loss: 0.5295 - acc: 0.9201 - val_loss: 0.8892 - val_acc: 0.7679\n",
+      "Epoch 11/100\n",
+      "50000/50000 [==============================] - 125s 2ms/step - loss: 0.5100 - acc: 0.9309 - val_loss: 0.8808 - val_acc: 0.7818\n",
+      "Epoch 12/100\n",
+      "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4926 - acc: 0.9397 - val_loss: 0.8404 - val_acc: 0.7894\n",
+      "Epoch 13/100\n",
+      "50000/50000 [==============================] - 125s 2ms/step - loss: 0.4807 - acc: 0.9470 - val_loss: 0.8600 - val_acc: 0.7928\n",
+      "Epoch 14/100\n",
+      "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4661 - acc: 0.9529 - val_loss: 0.9046 - val_acc: 0.7732\n",
+      "Epoch 15/100\n",
+      "50000/50000 [==============================] - 125s 3ms/step - loss: 0.4588 - acc: 0.9571 - val_loss: 0.8505 - val_acc: 0.7965\n",
+      "Epoch 16/100\n",
+      "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4558 - acc: 0.9593 - val_loss: 0.8748 - val_acc: 0.7859\n",
+      "Epoch 17/100\n",
+      "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4434 - acc: 0.9649 - val_loss: 0.9109 - val_acc: 0.7656\n",
+      "Epoch 18/100\n",
+      "50000/50000 [==============================] - 125s 2ms/step - loss: 0.4449 - acc: 0.9643 - val_loss: 0.8532 - val_acc: 0.7971\n",
+      "Epoch 19/100\n",
+      "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4349 - acc: 0.9701 - val_loss: 0.8677 - val_acc: 0.7951\n",
+      "Epoch 20/100\n",
+      "50000/50000 [==============================] - 125s 2ms/step - loss: 0.4351 - acc: 0.9698 - val_loss: 0.9145 - val_acc: 0.7740\n",
+      "Epoch 21/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4268 - acc: 0.9740 - val_loss: 0.8308 - val_acc: 0.8065\n",
+      "Epoch 22/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4243 - acc: 0.9741 - val_loss: 0.8229 - val_acc: 0.8075\n",
+      "Epoch 23/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4201 - acc: 0.9764 - val_loss: 0.8411 - val_acc: 0.8062\n",
+      "Epoch 24/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.4190 - acc: 0.9769 - val_loss: 0.8649 - val_acc: 0.7951\n",
+      "Epoch 25/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4139 - acc: 0.9787 - val_loss: 0.8257 - val_acc: 0.8071\n",
+      "Epoch 26/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4154 - acc: 0.9779 - val_loss: 0.8041 - val_acc: 0.8205\n",
+      "Epoch 27/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4128 - acc: 0.9798 - val_loss: 0.8296 - val_acc: 0.8115\n",
+      "Epoch 28/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.4121 - acc: 0.9798 - val_loss: 0.8241 - val_acc: 0.8074\n",
+      "Epoch 29/100\n",
+      "50000/50000 [==============================] - 125s 2ms/step - loss: 0.4093 - acc: 0.9807 - val_loss: 0.8575 - val_acc: 0.7913\n",
+      "Epoch 30/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.4048 - acc: 0.9826 - val_loss: 0.8118 - val_acc: 0.8166\n",
+      "Epoch 31/100\n",
+      "50000/50000 [==============================] - 126s 3ms/step - loss: 0.4041 - acc: 0.9837 - val_loss: 0.8375 - val_acc: 0.8082\n",
+      "Epoch 32/100\n",
+      "50000/50000 [==============================] - 125s 2ms/step - loss: 0.4045 - acc: 0.9831 - val_loss: 0.8604 - val_acc: 0.8091\n",
+      "Epoch 33/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4047 - acc: 0.9823 - val_loss: 0.8797 - val_acc: 0.7931\n",
+      "Epoch 34/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.4023 - acc: 0.9842 - val_loss: 0.8694 - val_acc: 0.8020\n",
+      "Epoch 35/100\n",
+      "50000/50000 [==============================] - 125s 3ms/step - loss: 0.3995 - acc: 0.9858 - val_loss: 0.8161 - val_acc: 0.8186\n",
+      "Epoch 36/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3976 - acc: 0.9859 - val_loss: 0.8495 - val_acc: 0.7988\n",
+      "Epoch 37/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.4021 - acc: 0.9847 - val_loss: 0.8542 - val_acc: 0.8062\n",
+      "Epoch 38/100\n",
+      "50000/50000 [==============================] - 125s 2ms/step - loss: 0.3939 - acc: 0.9869 - val_loss: 0.8347 - val_acc: 0.8122\n",
+      "Epoch 39/100\n",
+      "50000/50000 [==============================] - 125s 2ms/step - loss: 0.3955 - acc: 0.9856 - val_loss: 0.8521 - val_acc: 0.7993\n",
+      "Epoch 40/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3907 - acc: 0.9885 - val_loss: 0.9023 - val_acc: 0.7992\n",
+      "Epoch 41/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3911 - acc: 0.9873 - val_loss: 0.8597 - val_acc: 0.8010\n",
+      "Epoch 42/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3917 - acc: 0.9885 - val_loss: 0.8968 - val_acc: 0.7936\n",
+      "Epoch 43/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3931 - acc: 0.9874 - val_loss: 0.8318 - val_acc: 0.8169\n",
+      "Epoch 44/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3897 - acc: 0.9893 - val_loss: 0.8811 - val_acc: 0.7988\n",
+      "Epoch 45/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3876 - acc: 0.9888 - val_loss: 0.8453 - val_acc: 0.8094\n",
+      "Epoch 46/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3876 - acc: 0.9889 - val_loss: 0.8195 - val_acc: 0.8179\n",
+      "Epoch 47/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3891 - acc: 0.9890 - val_loss: 0.8373 - val_acc: 0.8137\n",
+      "Epoch 48/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3902 - acc: 0.9888 - val_loss: 0.8457 - val_acc: 0.8120\n",
+      "Epoch 49/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3864 - acc: 0.9903 - val_loss: 0.9012 - val_acc: 0.7907\n",
+      "Epoch 50/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3859 - acc: 0.9903 - val_loss: 0.8291 - val_acc: 0.8053\n",
+      "Epoch 51/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3830 - acc: 0.9915 - val_loss: 0.8494 - val_acc: 0.8139\n",
+      "Epoch 52/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3828 - acc: 0.9907 - val_loss: 0.8447 - val_acc: 0.8135\n",
+      "Epoch 53/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3823 - acc: 0.9910 - val_loss: 0.8539 - val_acc: 0.8120\n",
+      "Epoch 54/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3832 - acc: 0.9905 - val_loss: 0.8592 - val_acc: 0.8098\n",
+      "Epoch 55/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3823 - acc: 0.9908 - val_loss: 0.8585 - val_acc: 0.8087\n",
+      "Epoch 56/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3817 - acc: 0.9911 - val_loss: 0.8840 - val_acc: 0.7889\n",
+      "Epoch 57/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3827 - acc: 0.9914 - val_loss: 0.8205 - val_acc: 0.8250\n",
+      "Epoch 58/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3818 - acc: 0.9912 - val_loss: 0.8571 - val_acc: 0.8051\n",
+      "Epoch 59/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3811 - acc: 0.9919 - val_loss: 0.8155 - val_acc: 0.8254\n",
+      "Epoch 60/100\n",
+      "50000/50000 [==============================] - 125s 3ms/step - loss: 0.3803 - acc: 0.9919 - val_loss: 0.8617 - val_acc: 0.8040\n",
+      "Epoch 61/100\n",
+      "50000/50000 [==============================] - 125s 2ms/step - loss: 0.3793 - acc: 0.9926 - val_loss: 0.8212 - val_acc: 0.8192\n",
+      "Epoch 62/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3825 - acc: 0.9912 - val_loss: 0.8139 - val_acc: 0.8277\n",
+      "Epoch 63/100\n",
+      "50000/50000 [==============================] - 125s 2ms/step - loss: 0.3784 - acc: 0.9923 - val_loss: 0.8304 - val_acc: 0.8121\n",
+      "Epoch 64/100\n",
+      "50000/50000 [==============================] - 125s 2ms/step - loss: 0.3809 - acc: 0.9918 - val_loss: 0.7961 - val_acc: 0.8289\n",
+      "Epoch 65/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3750 - acc: 0.9930 - val_loss: 0.8676 - val_acc: 0.8110\n",
+      "Epoch 66/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3789 - acc: 0.9928 - val_loss: 0.8308 - val_acc: 0.8148\n",
+      "Epoch 67/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3783 - acc: 0.9929 - val_loss: 0.8595 - val_acc: 0.8097\n",
+      "Epoch 68/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3758 - acc: 0.9935 - val_loss: 0.8359 - val_acc: 0.8065\n",
+      "Epoch 69/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3784 - acc: 0.9927 - val_loss: 0.8189 - val_acc: 0.8255\n",
+      "Epoch 70/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3786 - acc: 0.9924 - val_loss: 0.8754 - val_acc: 0.8001\n",
+      "Epoch 71/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3749 - acc: 0.9936 - val_loss: 0.8188 - val_acc: 0.8262\n",
+      "Epoch 72/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3758 - acc: 0.9932 - val_loss: 0.8540 - val_acc: 0.8169\n",
+      "Epoch 73/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3740 - acc: 0.9934 - val_loss: 0.8127 - val_acc: 0.8258\n",
+      "Epoch 74/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3749 - acc: 0.9932 - val_loss: 0.8662 - val_acc: 0.8018\n",
+      "Epoch 75/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3721 - acc: 0.9941 - val_loss: 0.8359 - val_acc: 0.8213\n",
+      "Epoch 76/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3746 - acc: 0.9937 - val_loss: 0.8462 - val_acc: 0.8178\n",
+      "Epoch 77/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3741 - acc: 0.9936 - val_loss: 0.8983 - val_acc: 0.7972\n",
+      "Epoch 78/100\n",
+      "50000/50000 [==============================] - 122s 2ms/step - loss: 0.3751 - acc: 0.9933 - val_loss: 0.8525 - val_acc: 0.8173\n",
+      "Epoch 79/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3762 - acc: 0.9931 - val_loss: 0.8190 - val_acc: 0.8201\n",
+      "Epoch 80/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3737 - acc: 0.9940 - val_loss: 0.8441 - val_acc: 0.8196\n",
+      "Epoch 81/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3729 - acc: 0.9935 - val_loss: 0.8151 - val_acc: 0.8267\n",
+      "Epoch 82/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3735 - acc: 0.9938 - val_loss: 0.8405 - val_acc: 0.8163\n",
+      "Epoch 83/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3723 - acc: 0.9939 - val_loss: 0.8225 - val_acc: 0.8243\n",
+      "Epoch 84/100\n",
+      "50000/50000 [==============================] - 123s 2ms/step - loss: 0.3738 - acc: 0.9938 - val_loss: 0.8413 - val_acc: 0.8115\n",
+      "Epoch 85/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3714 - acc: 0.9947 - val_loss: 0.9080 - val_acc: 0.7932\n",
+      "Epoch 86/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3744 - acc: 0.9942 - val_loss: 0.8467 - val_acc: 0.8135\n",
+      "Epoch 87/100\n",
+      "50000/50000 [==============================] - 124s 2ms/step - loss: 0.3705 - acc: 0.9948 - val_loss: 0.8491 - val_acc: 0.8163\n",
+      "Epoch 88/100\n",
+      "50000/50000 [==============================] - 128s 3ms/step - loss: 0.3733 - acc: 0.9944 - val_loss: 0.8005 - val_acc: 0.8214\n",
+      "Epoch 89/100\n",
+      "50000/50000 [==============================] - 134s 3ms/step - loss: 0.3693 - acc: 0.9949 - val_loss: 0.7791 - val_acc: 0.8321\n",
+      "Epoch 90/100\n",
+      "50000/50000 [==============================] - 135s 3ms/step - loss: 0.3724 - acc: 0.9942 - val_loss: 0.8458 - val_acc: 0.8124\n",
+      "Epoch 91/100\n",
+      "50000/50000 [==============================] - 128s 3ms/step - loss: 0.3732 - acc: 0.9947 - val_loss: 0.8315 - val_acc: 0.8164\n",
+      "Epoch 92/100\n",
+      "50000/50000 [==============================] - 127s 3ms/step - loss: 0.3699 - acc: 0.9950 - val_loss: 0.8140 - val_acc: 0.8226\n",
+      "Epoch 93/100\n",
+      "50000/50000 [==============================] - 131s 3ms/step - loss: 0.3694 - acc: 0.9950 - val_loss: 0.8342 - val_acc: 0.8210\n",
+      "Epoch 94/100\n",
+      "50000/50000 [==============================] - 134s 3ms/step - loss: 0.3698 - acc: 0.9946 - val_loss: 0.8938 - val_acc: 0.8019\n",
+      "Epoch 95/100\n",
+      "50000/50000 [==============================] - 133s 3ms/step - loss: 0.3698 - acc: 0.9946 - val_loss: 0.8771 - val_acc: 0.8066\n",
+      "Epoch 96/100\n",
+      "50000/50000 [==============================] - 164s 3ms/step - loss: 0.3712 - acc: 0.9946 - val_loss: 0.8396 - val_acc: 0.8211\n",
+      "Epoch 97/100\n",
+      "50000/50000 [==============================] - 155s 3ms/step - loss: 0.3689 - acc: 0.9949 - val_loss: 0.8728 - val_acc: 0.8112\n",
+      "Epoch 98/100\n",
+      "50000/50000 [==============================] - 133s 3ms/step - loss: 0.3663 - acc: 0.9953 - val_loss: 0.9615 - val_acc: 0.7902\n",
+      "Epoch 99/100\n",
+      "50000/50000 [==============================] - 133s 3ms/step - loss: 0.3714 - acc: 0.9944 - val_loss: 0.8414 - val_acc: 0.8188\n",
+      "Epoch 100/100\n",
+      "50000/50000 [==============================] - 138s 3ms/step - loss: 0.3682 - acc: 0.9956 - val_loss: 0.8055 - val_acc: 0.8266\n"
+     ]
+    }
+   ],
+   "source": [
+    "trained_model = model.fit(\n",
+    "    train_images, \n",
+    "    train_labels,\n",
+    "    batch_size=50, \n",
+    "    epochs=100,\n",
+    "    validation_data=(test_images, test_labels),\n",
+    "    shuffle=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Model Output\n",
+    "\n",
+    "We can now plot the final validation accuracy and loss:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.9956000019311905\n",
+      "0.8320999944210052\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xd8VfX9+PHX+47sMMMegooILlDEWeusuLVW3KutqK1VO2y1/VZbW3+1rbVqtY4qaq17o8WF4iqCoOBgCSIjzBDIHne9f398TpKbkHGB3Nwk9/18PPJI7jnnnvM599yc92edz0dUFWOMMQbAl+oEGGOM6TwsKBhjjKlnQcEYY0w9CwrGGGPqWVAwxhhTz4KCMcaYehYUTFoRkUdE5I8JbrtSRI5NdpqM6UwsKBhjjKlnQcGYLkhEAqlOg+meLCiYTsertrlORD4XkUoReUhEBojIayJSLiIzRKR33PanishCESkRkXdFZEzcuvEi8qn3vqeBrCbHOllEFnjvnSUi+yaYxpNEZL6IlInIGhH5XZP1h3v7K/HWX+ItzxaRv4nIKhEpFZEPvWVHikhhM5/Dsd7fvxOR50TkPyJSBlwiIhNF5CPvGOtF5G4RyYh7/14i8paIbBGRjSLyaxEZKCJVItI3brv9RaRIRIKJnLvp3iwomM7qTOA4YA/gFOA14NdAP9z39moAEdkDeBK41ls3HXhFRDK8G+RLwGNAH+BZb7947x0PTAUuB/oC9wPTRCQzgfRVAhcBvYCTgCtF5HRvv7t46f2Hl6ZxwALvfbcBBwCHemn6JRBL8DM5DXjOO+bjQBT4KVAAHAIcA/zIS0M+MAN4HRgM7A68raobgHeByXH7vRB4SlXDCabDdGMWFExn9Q9V3aiqa4EPgDmqOl9Va4AXgfHedmcD/1XVt7yb2m1ANu6mezAQBO5Q1bCqPgfMjTvGFOB+VZ2jqlFVfRSo9d7XKlV9V1W/UNWYqn6OC0zf9lafB8xQ1Se94xar6gIR8QHfB65R1bXeMWepam2Cn8lHqvqSd8xqVf1EVWerakRVV+KCWl0aTgY2qOrfVLVGVctVdY637lHgAgAR8QPn4gKnMRYUTKe1Me7v6mZe53l/DwZW1a1Q1RiwBhjirVurjUd9XBX39y7Az73qlxIRKQGGee9rlYgcJCIzvWqXUuAKXI4dbx9fN/O2Alz1VXPrErGmSRr2EJFXRWSDV6X0/xJIA8DLwFgRGYkrjZWq6sc7mCbTzVhQMF3dOtzNHQAREdwNcS2wHhjiLaszPO7vNcAtqtor7idHVZ9M4LhPANOAYaraE7gPqDvOGmC3Zt6zGahpYV0lkBN3Hn5c1VO8pkMa3wssAUapag9c9Vp8GnZtLuFeaesZXGnhQqyUYOJYUDBd3TPASSJyjNdQ+nNcFdAs4CMgAlwtIkER+S4wMe69/wKu8HL9IiK5XgNyfgLHzQe2qGqNiEzEVRnVeRw4VkQmi0hARPqKyDivFDMVuF1EBouIX0QO8dowvgKyvOMHgf8D2mrbyAfKgAoR2RO4Mm7dq8AgEblWRDJFJF9EDopb/2/gEuBULCiYOBYUTJemqktxOd5/4HLipwCnqGpIVUPAd3E3vy249ocX4t47D7gMuBvYCiz3tk3Ej4CbRaQcuBEXnOr2uxo4ERegtuAamffzVv8C+ALXtrEF+DPgU9VSb58P4ko5lUCj3kjN+AUuGJXjAtzTcWkox1UNnQJsAJYBR8Wt/x+ugftTVY2vUjNpTmySHWPSk4i8Azyhqg+mOi2m87CgYEwaEpEDgbdwbSLlqU6P6Tys+siYNCMij+KeYbjWAoJpykoKxhhj6llJwRhjTL0uN6hWQUGBjhgxItXJMMaYLuWTTz7ZrKpNn33ZRpcLCiNGjGDevHmpToYxxnQpIpJQ12OrPjLGGFPPgoIxxph6FhSMMcbU63JtCs0Jh8MUFhZSU1OT6qQkVVZWFkOHDiUYtLlQjDHJkbSgICJTcWO6b1LVvZtZL8CduDFiqoBLVPXTHTlWYWEh+fn5jBgxgsYDYnYfqkpxcTGFhYWMHDky1ckxxnRTyaw+egSY1Mr6E4BR3s8U3DDAO6Smpoa+fft224AAICL07du325eGjDGplbSgoKrv40aBbMlpwL/VmQ30EpFBO3q87hwQ6qTDORpjUiuVbQpDaDyTVKG3bH3TDUVkCq40wfDhw5uuNsZ0MZFoDBHB7+u4jE5tJMrmihBbK0NkBnzkZAbICfqpDkcpqwlTWRvB7/ORFfSRFfATjsaoDEWpqo2QEfDRMztIz5wgKFTURqiojVAVilIbiRGKxIjG6qbaFoJ+ITvoJyvDT4bfhwgIggjEVFF1v0Pee2ujMapDUSprI9RGYvTNzaB/j0x652RQVF7Lmq3VFG6t4pg9B7DP0J5J/Zy6REOzqj4APAAwYcKETjdYU0lJCU888QQ/+tGPtut9J554Ik888QS9evVKUspMR6oJR1lfWkMkGqNPbga9cjLw+wRVJRxVFCUz4G/2vZFojOqwu8GEozHCESUci+GPu3GWVocpqQpTWh0mporPKzmW14QpqXbLe+cE2aVvLiMLcglHY2worWFDWQ2xmJKTESA3009FbZQ1W6pYs7WKytoIGQE/mQEffhFiqkRVqY3EKPP2WRuO0Ts3SN/cTHrlBN3NLuhHBNaWVFO4pZoNZTUE/EJOhp+sgJ+YKpGYEokqfp+7SQZ8PkqrwxRV1LKlMgRAht/dhDMCfgI+d64ZAR9Bf91vHxl+HxkBH+FojKLyWjZXhKgKRdz5ZPgJBnzUhmPURqKEIjFiCoq78fp9gl8Exd3IuzIRKMjL7NZBYS1u2sQ6Q71lXU5JSQn//Oc/twkKkUiEQKDlj3j69OnJTlra2FxRS+HWaob0yqYgLwMRIRSJsa6kmq1VIfr3yGJAfiZ+n7CutIYv15bydVEFGX4fORkBsjNcTWos1jgnF1Pw+8Dv8xHwCetLa1hRVME3myupqI2g3g1oS2WYzRW1jdIk4m56tZFY/bIMv4/cTD+ZAT+haIxaLxBEYjuf1wn4JOH9iMDAHln0yAoSirrcasQLQiJCZsBHj+wgfXIzCPp9lFSFWLyhjNKqMNXhKDXhKIrbx7A+OYwf3otITKkOuXU+EQJ+IeATojEXFCOxGLv0zWHCiN4U5GXiE6E6HKU6FCEcUyLRGJGoCyahSIxQ1AXI2kiM8poIQb8wemA+h+dlkp0RoCbsctbhaIzMgJ/MoAsiPqE+YNYFJ4A+ORn0y8+kV04G4WiMqpDL6edk+MnLDJKXFSAWUy9NUYIBH3mZfrKDAcLRmAu8VSEQIT8zQF5mgOwMP1lBH5kBv5cBcN+HSFSpCUepCrtA5cYddd8rEalPY0bAV/+Tk+EnNyNA0O+juLKWTeW1bKkIUZCfybDe2Qzpnd1ipqI9pTIoTAOuEpGngINwk4dvU3XUFVx//fV8/fXXjBs3jmAwSFZWFr1792bJkiV89dVXnH766axZs4aamhquueYapkyZAjQM2VFRUcEJJ5zA4YcfzqxZsxgyZAgvv/wy2dnZKT6zjlEbibJycxVfF1VQUROpz632yAoypHc2Q3tlU1wZYt6qrXy6aisVtRGG98lhl745lNdEmLF4IwvWlFA34G920E9+VoCiilriBwH2CeRkBHY6x9gvP5NdC3LZpW9OfZXA+GEurUN6ZRMM+Nji5YZrIzEyAz4yg+6fuaI2QkVNhNpIlMyAv/6GkB30kx10N7YMv7u5Bfxezt0LVD2ygvTKCdIzO1h/AwLIywrQKztIToafsuoIK4srWVlcSYbfx8CeWQzsmUXA56Mq5Ko8cjICDO6VtVM3GPUCp68Dq3/SycCeWeyVomMns0vqk8CRQIGIFAI3AUEAVb0PmI7rjroc1yX10vY47u9fWciidWXtsat6Ywf34KZTWr5Et956K19++SULFizg3Xff5aSTTuLLL7+s7zo6depU+vTpQ3V1NQceeCBnnnkmffv2bbSPZcuW8eSTT/Kvf/2LyZMn8/zzz3PBBRe063kkUygS46uN5SxeX8b60hrWl9ZQXFFLVtBPj+wA+VlB+uRk0Dcvgx5ZQVYWV/LF2lK+XFvKyuIqognmcPvlZ9I7J8gHy4qoCbsc+L5De3LtMXswZlA+60trWL2lirLqMIN7ZTOsTw69soNsKq9lfWk1pdVhRvXPY68hPdljQD4xdbnbqlAUweXeRNzNzufVA8dUvRxsjIL8THpkdd7nRHrmBNkvpxf7DWuuSrKtKZ8TJ97nZLqfpAUFVT23jfUK/DhZx0+liRMnNnqW4K677uLFF18EYM2aNSxbtmyboDBy5EjGjRsHwAEHHMDKlSs7LL3xaiOu6NwjK4jPJ8RiysriSr5cV0bh1qr67UKRGJsratlcHmJtSTVLN5QTijZUkxTkZdA3N5PaSJSymghl1eFtqjYG9shi7yE9OXGfQezeP4/d+uXRKyeITwSfCCXVIdaVVLN2azU5GQEOHNGHYX2yEXH19JvKaxGB/vlZO3XOnfkmb0xH6xINzdujtRx9R8nNza3/+91332XGjBl89NFH5OTkcOSRRzb7rEFmZkMuzu/3U11dnbT0lVaH+XTVVgpLqimvCVNeE6FwazVL1pexYnMl0ZgiAj2zg4QjrgdGc3rnBCnIy2RgzywuPXwE+wzpyV6DezZbNaGqlNdGKK4IUVIVYmjvHPrlt55zHdgziz0H9mh2nYgwoMfOBQNjzLa6XVBIhfz8fMrLm5/VsLS0lN69e5OTk8OSJUuYPXt2h6VrzZYqnpq7mqLyWmIK0ZiydEM5izeUNaprD/jcDXbMoB4cv9dAeudmUFoVYktViIDPx9jBPdhrcA9GFuTWN+AFfELAn/hjLiJCj6yglyvPbXN7Y0xqWFBoB3379uWwww5j7733Jjs7mwEDBtSvmzRpEvfddx9jxoxh9OjRHHzwwe1+/GhMeX9ZEVW1UTICPqKxGC98upYZizciIvTPz6y/mY8oyOHaY/bgwJG92b1fHvlZQbKCPnswzhgDdME5midMmKBNJ9lZvHgxY8aMSVGKOlbTc/109VZuenkhX6wtbbRdr5wg500czoWH7MKgnunRi8kY0zIR+URVJ7S1nZUUupCK2ghbKkNc+9R8cjMDlFSF+e8X6xnQI5M7zh7HmEE9CEVihGMxxgzsQXZG8vs0G2O6FwsKXUAo4p6UdU+XRpm/ppSKmgihaIzLv70rVx89itxMu5TGmJ1nd5JOKKZKVW3EjbvijYcCMKBHFoGeWbx33f4pTqExpruyoNCJRKIxtlSGKK4MEfb6/GcF/fTOzaBfXiYZAR9brEHYGJNEFhQ6gWhM2VRew+aKEKpKXmaAwb2yycv04/fZjKnGmI5jQSGFVJWymjDrSmoIR2P09gbsygpaA7ExJjUsG9oO6kZJ3R7RWIzVW6q45c9/I1RTzW798hjWJ8cCgjEmpSwotIPtDQrVoSjLN1VQVh3hqYfvY3Cez3oPGWM6BbsTtYP4obOPO+44+vfvzzPPPENtbS1nnHEGv//976msrGTy5MmsWr2G2nCEK6+9jmhVCRvWr+foo4+moKCAmTNnpvpUjDFprvsFhdeuhw1ftO8+B+4DJ9za4ur4obPffPNNnnvuOT7++GNUlVNPPZX333+foqIi+vQbwJ/uf5zczAA9/WEK+vTmnrvuZObMmRQUFLRvmo0xZgd0v6CQYm+++SZvvvkm48ePB6CiooKvvvqKPcdP5J23Z5Db42bO/d7p7HbEESlOqTHGbKv7BYVWcvQdQVW54YYbuPzyy+tfry2pZktliDfe+4j5/3uHG3/7W4455hhuvPHGlKbVGGOasobmdhA/dPbxxx/P1KlTqaioAGDBkhUsW7WWaEUxuw3qw4UXXsh1113Hp59+us17jTEm1bpfSSEF4ofOPuGEEzjvvPM45JBDiMaUYFYO9zwwlY0rC7l48hn4fD6CwSD33nsvAFOmTGHSpEkMHjzYGpqNMSlnQ2cnSWl1mNXFleRnBd0E7+00PEVnPFdjTOeX6NDZVn2UBOFojMKtVWRl+BnWp/0CgjHGJJsFhSTYUFpDTGFY7xz8PgsIxpiuo9sEhc5SDVZRG2FrVYh+eRntPmRFZzlHY0z31S2CQlZWFsXFxSm/acZUWVdSTYbfR//8rHbdt6pSXFxMVlb77tcYY+IltfeRiEwC7gT8wIOqemuT9bsAU4F+wBbgAlUt3N7jDB06lMLCQoqKitoh1TuuvCZMaXWEvnkZLC1p/4HtsrKyGDp0aLvv1xhj6iQtKIiIH7gHOA4oBOaKyDRVXRS32W3Av1X1URE5GvgTcOH2HisYDDJy5Mj2SPYOW7axnIvu/pDDdy/gwYv3TmlajDFmRyWz+mgisFxVV6hqCHgKOK3JNmOBd7y/ZzazvkuoCUf5yZPzyc0I8P++u0+qk2OMMTssmUFhCLAm7nWhtyzeZ8B3vb/PAPJFpG/THYnIFBGZJyLzUl1F1Jw/TV/Mkg3l3HbWfu3elmCMMR0p1Q3NvwC+LSLzgW8Da4Fo041U9QFVnaCqE/r169fRaWzVjEUbefSjVfzg8JEctWf/VCfHGGN2SjIbmtcCw+JeD/WW1VPVdXglBRHJA85U1ZIkpqld1YSjXP/CF+w1uAe/nDQ61ckxxpidlsySwlxglIiMFJEM4BxgWvwGIlIgInVpuAHXE6nLeOWzdWyuqOU3J40hM2DTaBpjur6kBQVVjQBXAW8Ai4FnVHWhiNwsIqd6mx0JLBWRr4ABwC3JSk97U1UembWS0QPyOWTXbZpBjDGmS0rqcwqqOh2Y3mTZjXF/Pwc8l8w0JMsnq7aycF0Zt5yxt41tZIzpNlLd0NxlPTJrJT2yApwxvmmHKmOM6bosKOyADaU1vPblBs4+cBg5GTYlhTGm+7CgsAMen7OKmCoXHjwi1Ukxxph2ZUFhO9VGojwxZzXH7Nmf4X1zUp0cY4xpVxYUttMbCzdSXBniwkNGpDopxhjT7iwobKfHZ69iWJ9svrV7QaqTYowx7c6CwnZYvqmcOd9s4byJu+CzGdWMMd2QBYXt8MScNQT9wlkTbE4DY0z3ZEEhQTXhKM99sobj9xpIQV5mqpNjjDFJYUEhQa9+vp6ymgjnH7RLqpNijDFJY0EhQY/PWcWu/XI5eNc+qU6KMcYkjQWFBKzcXMn81SWce+BwG+fIGNOtWVBIwMylmwA4fq+BKU6JMcYklwWFBMxcWsSu/XLtCWZjTLdnQaENVaEIs1cUc/Rom2rTmLRU/DXUlqc6FR3GgkIbPvq6mFAkZvMvm+6hshiqt6Y6FV3HivfgnwfD8z9MdUo6jAWFNryzZBO5GX4mjOid6qSYdKPa/PLKzS2vAyhbB4+eCnPub7w8XA0PHAkPHQ/RyI6lp2zdtstjMVj6GoRrtl23cSHEott/rEStng0f3ePS0N7Wfw5PnQ/ig69eh3UL2v8YiQpXw6s/hS3fJP1QFhRaoaq8u7SIw3YvsDmYTccq/ARuHQ4bvmi8fP3ncNsesOCJ5t+3aTE8eBx88x68+X+weXnDull3Q+lq2LwUFjy+/WmadRfcsS9sWdF4+edPw5PnwFPnQqjKLVOFt/8A9x7q3tfeYlF47y/w8Anwxq/htV82DpSLX4XHz4Ky9Tu2/60r4fHvQVZPmPKe+/3+X1vevmITFM6DmtIdO15rStbA1ONh3sOw8sP2338TFhRasWxTBWtLqtO36mj1bJh9X3JyYaZ1i6dBbZm78cX74G+gUfjw79tel28+cKWAWATOfx4C2fDfn3k5/PXw4e0w5hQYeiC8e2vDDTwRNWXeMcPbBqTPnnA3zRXvuhtxTSn89+fwwW0QzIV5UxunNRZ1OfBnL4Wv3oBouPVjV2+FL5+HD++AuQ/CZ0/DY6fDzFtg7zPhoCth7r/g3T+5c33/Nnj6fFj2pqv22Z5SkSosfAkeOQUitXDhC9B/TzjoCljyqiv5xIvFYM4DcNd4ePAYF8hvHwtv/rb146yZC09fAKVrW99u1SxXutvyDZz3NOx/YeLnsoNs2rBWzFziuqIeObpfilOSAqVrXe6veits+BxOuQv8bXxdYjFYPQuGHwK+7SxZhavhkZNhr9Ph0J/seLpbE6py/9h7n9ly+raugtdvgKEHwAGXQk6KHlZc8S4gLjhsWgz9x7hc/6KXYcDesPFLd9MbPcltv2WFuyH3Gg4XPOd+H/NbmP4L+OI5+PptFyy+80d3bR85ET6+Hw7/aWLp+fh+913ouzsseBKOvMF9hiVrXDA68gbouxu8MMWVJmpK4LBrYeA+8PwPYMU7sPuxbl8LX3TXISMPFr4AOQVw0m2w1xmNj7nsLfjgdlgzxwXCeMEcOO0eGHe+ex0qh/f+DMtnwNpPYJ/JsMuh8Oq18N6tcPT/tX5+0bD7zGfeAuvmQ8FoOOsR6DfarT/oCldN9f5tcNbDbtmGL13QXTMHdjsaDrjENUqv/MCVjkafCLscsu2xQpXuMylZ5a7tJf+F/Ga6u29Z4aoBe4+Ac5+EglGtn0M7saDQiplLN7HnwHwG9cxOdVI6ViwKL17uckoTp8DHD7hc65kPQaCVcZ/mPwavXA17ngzf/RdkbEcX3ll3w9p5ULTE/aMn42b80T0w84/uBjD+/G3Xr/+sIae79L8ul77v2TDqOzBgLPQaAb42CtfffOBKWBk57saV0xcK9oA+u0IgI7F0Vm1xaTnoCvj03+7GeOa/4H93uM//vGfgoePgo7tdUFB19c2+AFz0EvQY7PYz4fsuVz/95+6cDv+pu8H0HgGjjocP/g77Xwxbv4FPH4NwlbuRDxjbOD01pTDrH7DHCbDvZHjuUlc9tdvRruoIdcv7jHTpe+nHcNzNcNg1EAm5m/68h11QiMVcNUy/MXD5e/D1O/DOH+G1X7n9B7PcMWvLXS4/qyd862fuGvQf4wJ7bTlk94bcvg1pPPlOl87Fr8AxN8LhPwMR9516/zaXUdn9mG0/64UvuSD19UyoLYWew+D0e911j8845PSBiZe50srwQ1ywXvmBS8fp98F+57jjgbtud+4H7/4/uPiVbY854/dQshqO+4Mrsf37NBcYcpsMx//F8y6QX/QS9Oy4QTgtKLSgvCbMvJVbueyIXVOdlI73vzvdF/7Uu11xtc9u8Pqv3Jf3yBtg5BEN/wDx5j/m/kmW/BcePQXOfQryEihlla51VRtDD4TCuTD7Xjj6N9tuV/SVqzsOZsPkx9ouucSLRuATL4f37p9caaHuBgQuh/nMxS79U94DjcGc+9xN79NH3TYZeXDKnbDP95o/xtwHYfp17r1Nid/lsocdCMMOhsHjXW4+q8e2237zHqCw93fBH3Q3//0vgs+ecrnRnkPcjeet37rGz02LXS73xNsaAgK4m9rJf4d/HQV5A+BbP29Yd+xNcO9hcPcEqCp2VU3+IHz+jLshHnm9u8mDux41pXDUDS4HndUL5j8Oux7l0jT80IZtx5wCo09qCJ6BDBeAZ93tqrDWzHaB/3tTXQAZfYILnv8+FT57EiZc6t43b6orbVzwgiu11cnMh/wB235m/gCc9SiUFkLvuPHJTvgrrP0UXrgMfjSn8fdx+dvw7MWQNxDGnuoCzx7Ht5zxOeQq13j/2nXu2h37OxdUm2ZgMnLg8GtdW8fKD2HE4Q3rVn7oSl0HXQGHXQ2Dx7mMyL9Pgx+8CRm5DdsufMEFoA4MCACirfVi6IQmTJig8+bNS/px3l68kR88Oo8nLjuIQ3frwhPqVG911Q7l66B8g/vS9R4BvUe6G0jTm3vhJzD1Oy63f9YjDes/exreuMHdQPrt6XKB485reF/RUrhnoque6D3S5fKye7sbWMVGd1M58yEYddy2aXz+h7BoGlz1sWscXfE+/PQLl0sEV7X0wd9cLs2fAeFKOOKXzQeOlix+1dUz15V8jv8THPIjt27pa65+t98YOP9Z6DGo4X2hSti0xFXXfPyA+zyv+czdQOuowjt/cGncYxJ89wG3LFwN5euheDls/so1Eq+Z4252dTJ7uGB49n8aSlavXANfvgC//MZ93nfu64JKtBaunu9uSDWlcPternqicJ6rWrj09eZLMoumQY8hjW+u4Oq9V/3PXcd9znIlxP/d4W58kRoYOtHd5N//q8sInOM1Tv/3Fy4DcM7j8J8z4dR/uKDVkuKv4R/7w1G/cbnyWAR+NLshJ67qAldNKVw1z5Xk7tjHlVguejmx69uaTUtcg/fEy+CEPzcsf/gkV0VzzYLWS8Dxvnnf9bLa/ZjWq0jD1a600HcUXPpftyxU6QIxClfOaggAX70BT0xu/J3ctAT+eZALagdN2e5Tbo6IfKKqE9raLqklBRGZBNwJ+IEHVfXWJuuHA48CvbxtrlfV6clMU6JmrygmI+Bj/+FduCtqJAT/OMDdWJoz6nj3j113g6sshmcvcTmnU+5oHDD2OxvGnuYa/ObcBy9dCbn9YZRXTzz/P676Yt+zIa+/Kw6/9Vu37+GHuJvhqz+DH89pXK20ejZ88SwccZ0LVkdc56oAPn7A/V20FJ65yOUu9z0bvnMLzLjJ3ah2ORR2Oyqxz2LeQ5A/2P3jbV7mGkHHXwCbFrlzHrgPXDRt25x7Rq67mQ49wNX7PjHZ3dj2ndywzfTrXEPn/hfDSbc3lGCye7kAM2T/hm1jMShe5noVla11aZn/mKsmOvgKt82Kd2HEt9x+8ge4/X58P+x3rgsI4ALm/hfB7HvAF3QlmJaqtsae2vzy7/xh22XH3exysQseh4Uvu2sIroRYZ/z57nxf+hEEstz3ojV9d4OR33bVONFaV7UYf0MVcVVbz1zkqmUqN0PlJvjW1Nb3m6j+e7prPW8qHPJj9xmungOrPnTfh0QDArjgmIhgtqvCev1XrkRSttZVA279xv1vxJcI9jjelbY+uscFLn8QFr0ESMvXLplUNSk/uJv818CuQAbwGTC2yTYPAFd6f48FVra13wMOOEA7wsl3faCT75vVIcdKmuXvqN7UQ/WDv6uu/1y1fJNq8deqy99WffsPbt1LP1aNxVQjYdVHTla9uZ9q4bzW9xuuUb1zvOqd49zfkZDqX3ZXfeIYPxUKAAAeO0lEQVTclt+z4n13vLf/2LCsplz13sNVb9tTtbaiYfl/zlK9dYTqJ/9W/eMg1b/sprrsrYb1tRWqd090y8vWNz5OZbHqivdUv57pzktVdfNyd+x3/+xeF37iXj9/meqfhrlzqShq69NUjUZV/3Gg6r2HNex7yWtuX69d37Bse009wX0G4RrV4hVuf7Pvb1hfuk71sTPdtYu3dZXqLUNUZ966Y8dNRNEy1VUfNV4Wi6nec4hL57PfT2w/X77gtr9rf9VoZNv10Yi7Dvcernr73qr/OnbHP8/mlBS67/aLV7rXj09237H47117C1Wr3jZa9aae7tzvO0L1qzeb33bJdLfNZ0+713dPVJ16YrsmB5inCdy7k1lSmAgsV9UVACLyFHAasCg+JgF1WbOeQDNPxnS80uowC9eV8pOjO6a1f4dVbXE5xpaKsV+94XJyE6fE5c77uUbP3Y52L9//q6sPrix2RePT74UhBzS/vzqBTDjxL67qYNY/YMBeLmfXXONtnZHfclUU/7vDNcpl93a57o1felUncTmnI66Dh46FaVe5+vezHm5cV56R66q2HjgK7jvcNWSKz1U/lBU2bLfvOXDy7S6H6As0VHEM2R/Gnu7aC/IGwoUvbtvI1xyfz+U0X7na1fsPGud6t/TfC479ffPtLIk44jrXxXLB44C3j12PbFjfY5DrUdRUr+Hwi6WNP7v2VrA7sHvjZSIu5/3GDa70kojRJ7mG5gMva/776vO7KslXrnavT7ptxz/P5vQc4nLhs//pqn6+et1VZyXzswtmwaRbXSn6oMvd+bd0TqOOd+01/7vL9S4rWuLaiFIgaW0KIvI9YJKq/tB7fSFwkKpeFbfNIOBNoDeQCxyrqp80s68pwBSA4cOHH7Bq1aqkpLlOytsTlr8NM37nGuNa6oa2cRHcd5hrpBu0n6uXPvynrsoCXD3tXePcF+38Z5rfh6prgPviWff6oCsa17m25ekLYNkMGOQ90PSzxY3r2psq3wD/mOAa1yo3u/d8byqMOXnbbV//tSuCH3l9y/tcNsNVvWjM/QRzXIAauI9rsH73VtdjpWydq2Y665GG9275xjUEHvUbGLh34uccroE79nYBIW+Aaxy97G3XcLyjVOHBY11gHbiv6xL504Xte1Nsb5GQ6zm0x/Htl85IrauHzymAKz5o//OvLHb7D1e579ZPv3SZk87i08dcRmj4oa5B/mdLmm9U30Gdok0hAecCj6jq30TkEOAxEdlbtXH3DVV9AFfVxIQJE5LeMj7nmy1k+JPYnqDqGgfrbsYn/LnxP8B7f3HPBjx2huuREJ9LrrPIa4Db7xzXA2XWXa5xsO6mvnmZeyrz0KtbToeI6+tdU+b+/s4ft+88jv+TuzGvmeN6ZrQWEMDVyR/1a5fDzMhzud+W6mgn/b+2jz/q2IY2jaZ2P8YFyud/6Bp2D2wydk2fka7v9/YKZsHEy13XVnD1xjsTEMB99t/+pSs5lax2XXI7c0AA16uo7hmJdttnJlw63ZVuk3H+uX3h0Ktc77MJ3+9cAQFcO9U7f3TP+oz4VrsGhO2RzKCwFhgW93qotyzeD4BJAKr6kYhkAQXApiSmq02zVxQzbngvsoLtPLSFqmtQ/PB2d8MWn8vh7nF8Qx/qDV+4XMK4C1xj03/OdP8oTb/AS6fDsIPgpL+51y9e6fb97V+5LnLL3nDLR32n9TQFMlsuSbSl1zD49nXwzi0wPsEnLSdOcc88jD7BlXCSafdj4IoPofBj2OWw9tvvgT9wPY16DXefd3sY9R1XStjweeOqo3TTJ8ldwA/9ietldfCVyT3Ojghkus4GM37nuiOnSDKHuZgLjBKRkSKSAZwDTGuyzWrgGAARGQNkAUVJTFObymrCfLm2lIN37dv2xtsjXAMvX+XqTHP7w2n/hF8sgx5DXcmgrhpv7kOuz/jxf3Q9g4qXw5PnuuJ6nZI17uYx+oSGZYf+xBWL5z7kXn/1hqub7BUfl5Pg8J+5Lpr990xse3/AVQklOyDU6TnEPSnbnjnPnD6uBHfxK42fddgZIu7Zgd4jYLdmHrIy7SMj13VlTtWT6m2ZOMU9/7Dv2SlLQtKCgqpGgKuAN4DFwDOqulBEbhaRun5WPwcuE5HPgCeBSzRZjRwJmrdyCzGlfedirhvQasF/XP/677/uGmVzC9xDLmtmu4fFakrdw0N7n+lKBrse6R4gW/0RfP5Uw/6+et39Hn1iw7IBY2H341zXxfKNbsyUPY5vv3NoiUjyA09nNGjf9i/e736sC7C57ZwhMV1HRq5rG0xmA3gbkjognqpOV9U9VHU3Vb3FW3ajqk7z/l6kqoep6n6qOk5V30xmehIxe0U7tyeEqlzbwJYV7gnfo3/TuPfF+AtdD5j3/uIeEAtXuuqJOvtOdtUKH97RMATx0unuoZimjdCHXQ2VRfDiFDdWzB7tXOdrjOn2bJTUJmavKGbcsHZsT5jxO/ew0tmPNa7uqRPMcqWFlR+4BrDB+zd+2EnEDU+w5WvXuFxT5sbXaW5fI77lqmVWvOvG3Gmra6kxxjRhQSFOeX17QjtVHX39jjfOyZWtNx7ufzHk9oPqLdv2kgE31EDf3V0D9fK33PDF8VVHdUQaehvtftz2j1RqjEl7FhTiLFhTQkzhwJHtEBSqt7rRIgtGuwbE1mTkuP7yBaOb73Xg87t6xg1fwNs3u1LAsInN72vs6a67Xd2QCcYYsx0sKMRZtK4MgL0H99z5nb3+a/cw0ncfcA/KtGXCpW5AuJa23WeyG9Rs60rXVtBSKcAfcCNj7mzfeWNMWrKgEGfR+jIG9cyid26C4963ZOsq11vooCvc07vtIZDRUDXUXHuCMca0g1Q/0dypLF5fxphBzYxvv70+fgCQ9n9A5sAfun73o09q3/0aY4zHSgqemnCUr4sqGbuzQaG23D1ZvNfp7T85hj/gGp3bmv3LGGN2kN1dPMs2VhCN6c6XFOY/7oZxOPhH7ZMwY4zpQBYUPIvXu0bmMYPyd3wnsaibgGboRBja5mCExhjT6VhQ8CxaX0ZOhp9d+u7E4+Vfve5mVjrESgnGmK4poYZmEXkBeAh4remw1t3FovVljB6Yj9+3nQOnrZ7tJqcpXu6eNO45DPY8JTmJNMaYJEu099E/gUuBu0TkWeBhVV2avGR1LFVl8foyTt2vmXkLWrNqFjxykhv+uscQNxftt37WMEevMcZ0MQndvVR1BjBDRHriJsaZISJrgH8B/1HVcBLTmHRrS6opr4lsXyNzZTE89wM31PEP3+68Q/EaY8x2SLhNQUT6ApcAPwTmA3cC+wNvJSVlHajuSeaEg0IsBi9eDlWb3RSPFhCMMd1Eom0KLwKjgceAU1R1vbfqaRGZl6zEdZTF68sRgT0HJtjzaNZdbmC6E2/ruMlijDGmAyRa+X2Xqs5sbkUiE0F3dovXlzGiby65mQl8HLUVbh7VMac0P6KpMcZ0YYlWH40VkV51L0Skt4h0m36Xi9aXJf58wrpP3dDV+1/c+SdXN8aY7ZRoULhMVUvqXqjqVuCy5CSpY5XXhFm9pSrx4S0K57rfNoGNMaYbSjQo+EUassUi4gd2cijRzmHphnJgOxqZ18x1U2Fa47IxphtKNCi8jmtUPkZEjgGe9JZ1ed9srgRgt355bW+s6koKLU1wY4wxXVyiDc2/Ai4H6saCfgt4MCkp6mDrSmoAGNQrq+2Nt6503VBtXCNjTDeV6MNrMeBe76dbWVdSTb/8TDIDCcxnXNeeMPTA5CbKGGNSJKHqIxEZJSLPicgiEVlR95PA+yaJyFIRWS4i1zez/u8issD7+UpESprbTzKtK61mcK8EpssEFxSCudB/bHITZYwxKZJo9dHDwE3A34GjcOMgtRpQvMboe4DjgEJgrohMU9VFdduo6k/jtv8J0OETC68tqU78obU1H8OQ/VueH9kYY7q4RBuas1X1bUBUdZWq/g5oa07IicByVV2hqiHgKeC0VrY/F9eA3WFUlXUl1QzumUBJIVQFG7+0RmZjTLeWaEmhVkR8wDIRuQpYC7TVXWcIsCbudSFwUHMbisguwEjgnQTT0y62VoWpCccSqz5avwBiEWtPMMZ0a4mWFK4BcoCrgQOAC4CL2zEd5wDPqWq0uZUiMkVE5onIvKKionY76LqSaoDEgkL9Q2vW88gY0321GRS8toGzVbVCVQtV9VJVPVNVZ7fx1rXAsLjXQ71lzTmHVqqOVPUBVZ2gqhP69evXVpITttYLCkOaCwqhSvjP9+D9v0JNmQsKvUdCXvsd3xhjOps2q49UNSoih+/AvucCo0RkJC4YnAOc13QjEdkT6A18tAPH2CkNJYVmnlEoXu5GQl3+Fsy6282/PPqEDk6hMcZ0rETbFOaLyDTgWaCybqGqvtDSG1Q14rU/vAH4gamqulBEbgbmqeo0b9NzgKdUVXfoDHbCupJqMgM++uQ2M2JHqMr9PuYmWDPHzb+865EdmTxjjOlwiQaFLKAYODpumQItBgUAVZ0OTG+y7MYmr3+XYBra3bqSGob0ykaaG+007MW+XQ51U2yWb4RcqzoyxnRviT7RfGmyE5IKa0uqGdK7hUbmsKtaIpjjfucP6JhEGWNMCiU689rDuJJBI6r6/XZPUQdaV1LNUaP7N7+yrvooI7fjEmSMMSmWaPXRq3F/ZwFnAOvaPzkdpzYSZVN5bcvdUeuqj+pKCsYYkwYSrT56Pv61iDwJfJiUFHWQjaW1QAs9jyCupGBBwRiTPhJ9eK2pUUAL9S5dQ6vPKACEvaAQtOojY0z6SLRNoZzGbQobcHMsdFltPs0cqgR/BvgTrWEzxpiuL9HqowSHEe066oLCwJ4tVB+Fq6w9wRiTdhKdT+EMEekZ97qXiJyevGQl39qSagryMskKtjAMdqjKeh4ZY9JOom0KN6lqad0LVS3Bza/QZa0tqWZIa1NwhiutpGCMSTuJBoXmtuvSle3rStqYcS1UBcEEZ2QzxphuItGgME9EbheR3byf24FPkpmwZHKT69S0HhTCVn1kjEk/iQaFnwAh4GncDGo1wI+TlahkK6kKUx2Oth0UrPrIGJNmEu19VAlcn+S0dJiGZxRaaVMIVUGPwR2UImOM6RwS7X30loj0invdW0TeSF6ykiuhGdfClfbgmjEm7SRafVTg9TgCQFW30oWfaC6qcENc9MvPbHmjUJUNcWGMSTuJBoWYiAyveyEiI2hm1NSuorI2AkB+VrDljaxNwRiThhLtVvob4EMReQ8Q4FvAlKSlKskqaqMA5LT04FosZr2PjDFpKdGG5tdFZAIuEMwHXgKqk5mwZKqoiZCb4cfna2bGNYBIkwl2jDEmTSQ6IN4PgWuAocAC4GDgIxpPz9llVNZGyMtq5dRtgh1jTJpKtE3hGuBAYJWqHgWMB0paf0vnVRGKkJvZSlCon2DHnmg2xqSXRINCjarWAIhIpqouAUYnL1nJVVETIa+1oFBXUrDqI2NMmkm0obnQe07hJeAtEdkKrEpespKrsraNoBD22hSs+sgYk2YSbWg+w/vzdyIyE+gJvJ60VCVZRW2EYbmtlAJsfmZjTJra7uk4VfU9VZ2mqqG2thWRSSKyVESWi0izw2SIyGQRWSQiC0Xkie1Nz46oaKukYPMzG2PSVNKGvxYRP3APcBxQCMwVkWmquihum1HADcBhqrpVRDrkKem2q4/qSgpWfWSMSS/bXVLYDhOB5aq6witVPAWc1mSby4B7vGEzUNVNSUxPvcraaOu9j6ykYIxJU8kMCkOANXGvC71l8fYA9hCR/4nIbBGZlMT0AFAbiRKKxsjLbOFpZnBPM4OVFIwxaSfVs6cFgFHAkbgH494XkX3iB98DEJEpeMNqDB8+vOk+tkulN8RF6yUFr/rISgrGmDSTzJLCWmBY3Ouh3rJ4hcA0VQ2r6jfAV7gg0YiqPqCqE1R1Qr9+/XYqUXWD4bXeplAFCARamW/BGGO6oWQGhbnAKBEZKSIZwDnAtCbbvIQrJSAiBbjqpBVJTBMViQSFkDcYnrQwNpIxxnRTSQsKqhoBrgLeABYDz6jqQhG5WURO9TZ7AygWkUXATOA6VS1OVpqgISi0OcyFDXFhjElDSW1TUNXpwPQmy26M+1uBn3k/HaK+pNDWgHj24JoxJg0ls/qoU0q4TcGGuDDGpKG0CwoVNYlUH1lJwRiTntIvKCTc0GxBwRiTftIuKNQ/p5DR2sNrlfbgmjEmLaVdUKioDZMV9BHwt3LqVlIwxqSpNAwK0darjsDaFIwxaSvtgkKbI6RCw8NrxhiTZtIuKFTUtjE/M3htClZSMMakHwsKTUVCEItYm4IxJi2lXVCorI2Qn9AEOxYUjDHpJ+2CQpslhXC1+21BwRiThtIuKFS2FRTqZ12zhmZjTPpJu6BQURshv7XB8Kz6yBiTxtIqKESiMWrCMXIzbH5mY4xpTloFhYapONsY4gJsmAtjTFpKq6BQEXKD4bVafWQlBWNMGkuroFCZ0KxrXlCwNgVjTBpKq6BQnshcCiGv+sh6Hxlj0lBaBYWEZ10DKykYY9KSBYWmQhYUjDHpK62CQnlCJYVK8GeAv41B84wxphtKq6CQWENztZUSjDFpK02DQivPKdhcCsaYNJbUoCAik0RkqYgsF5Hrm1l/iYgUicgC7+eHyUxPeW2EDL+PzEBb8zNbScEYk56SVnEuIn7gHuA4oBCYKyLTVHVRk02fVtWrkpWOeG4wvFYCAtj8zMaYtJbMksJEYLmqrlDVEPAUcFoSj9emytooea09zQze/MxWfWSMSU/JDApDgDVxrwu9ZU2dKSKfi8hzIjKsuR2JyBQRmSci84qKinY4QRW1kdYHwwP38JqVFIwxaSrVDc2vACNUdV/gLeDR5jZS1QdUdYKqTujXr98OH6yiJtJ6d1TwSgoWFIwx6SmZQWEtEJ/zH+otq6eqxapa6718EDggiemhMtTGBDtgvY+MMWktmUFhLjBKREaKSAZwDjAtfgMRGRT38lRgcRLTQ0VtJIE2Bet9ZIxJX0nrfaSqERG5CngD8ANTVXWhiNwMzFPVacDVInIqEAG2AJckKz3gVR+12aZgvY+MMekrqWM5qOp0YHqTZTfG/X0DcEMy0xCvzfmZYzGI2BPNxpj0leqG5g4TiymVoWa6pJZvgJevgooiFxDAgoIxJm2lTVCoDNUNhtfk4bVv3of5j8HzP4DacrfMGpqNMWkqfYJC/fzMTUoKFRvd72/egzf/z/1tJQVjTJpKm6BQ0dKw2RUbIZAF4y+EL551y6yh2RiTpiwoVGyCvP5w4l9h4D5umQ1zYYxJU2kTFFqcS6FiI+QNgGA2TH4MxpwKg8elIIXGGJN6aTO9WKslhT67ur/7jISzH+vglBljTOeRNiWFippW2hTy+qcgRcYY0/mkTVCo65LaqPooGoaqYld9ZIwxJn2CQrPVR5XeMNxWUjDGGCCN2hQuPmQEp+w7mKxgXByse0bBSgrGGAOkUVDIzQw00/Nok/ttQcEYY4A0qj5qVn1JwaqPjDEGLCi437kWFIwxBtI+KBRBVk8IZqU6JcYY0ymkeVDYaO0JxhgTJ82DwiYLCsYYEyd9gkK4GtZ/3niZPc1sjDGNpE9Q+N9dcP8RDRPpgJUUjDGmifQJCoPHAdpQWghVQqjcSgrGGBMnfYLCIG847PUL3G97cM0YY7aRPkEhfwDkD4Z1TYKCPaNgjDH10icogKtCWjff/W1PMxtjzDaSGhREZJKILBWR5SJyfSvbnSkiKiITkpkeBo+H4uWusdkGwzPGmG0kLSiIiB+4BzgBGAucKyJjm9kuH7gGmJOstNQbFNfYXLEJxAe5BUk/rDHGdBXJLClMBJar6gpVDQFPAac1s90fgD8DNUlMi1M39/K6+a6kkFMAPn/SD2uMMV1FMoPCEGBN3OtCb1k9EdkfGKaq/21tRyIyRUTmici8oqKiHU9RXn/oMcT1QLJnFIwxZhspa2gWER9wO/DztrZV1QdUdYKqTujXr9/OHXjQONcDyZ5mNsaYbSQzKKwFhsW9Huotq5MP7A28KyIrgYOBaclvbB4Hxctg6zdWUjDGmCaSGRTmAqNEZKSIZADnANPqVqpqqaoWqOoIVR0BzAZOVdV5SUyT64EEUL3VSgrGGNNE0oKCqkaAq4A3gMXAM6q6UERuFpFTk3XcNtU92QxWUjDGmCaSOkezqk4HpjdZdmML2x6ZzLTUy+sHPYZCWaGVFIwxpon0eqK5Tl3XVCspGGNMI+kZFOqqkKykYIwxjSS1+qjTGncehCuh7+6pTokxxnQq6RkUeg6BY3+X6lQYY0ynk57VR8YYY5plQcEYY0w9CwrGGGPqWVAwxhhTz4KCMcaYehYUjDHG1LOgYIwxpp4FBWOMMfVEVVOdhu0iIkXAqh18ewGwuR2T01Wk43mn4zlDep53Op4zbP9576Kqbc5S1uWCws4QkXmqmtxJfDqhdDzvdDxnSM/zTsdzhuSdt1UfGWOMqWdBwRhjTL10CwoPpDoBKZKO552O5wzped7peM6QpPNOqzYFY4wxrUu3koIxxphWWFAwxhhTL22CgohMEpGlIrJcRK5PdXqSQUSGichMEVkkIgtF5BpveR8ReUtElnm/e6c6re1NRPwiMl9EXvVejxSROd71flpEMlKdxvYmIr1E5DkRWSIii0XkkDS51j/1vt9fisiTIpLV3a63iEwVkU0i8mXcsmavrTh3eef+uYjsvzPHTougICJ+4B7gBGAscK6IjE1tqpIiAvxcVccCBwM/9s7zeuBtVR0FvO297m6uARbHvf4z8HdV3R3YCvwgJalKrjuB11V1T2A/3Pl362stIkOAq4EJqro34AfOoftd70eASU2WtXRtTwBGeT9TgHt35sBpERSAicByVV2hqiHgKeC0FKep3anqelX91Pu7HHeTGII710e9zR4FTk9NCpNDRIYCJwEPeq8FOBp4ztukO55zT+AI4CEAVQ2pagnd/Fp7AkC2iASAHGA93ex6q+r7wJYmi1u6tqcB/1ZnNtBLRAbt6LHTJSgMAdbEvS70lnVbIjICGA/MAQao6npv1QZgQIqSlSx3AL8EYt7rvkCJqka8193xeo8EioCHvWqzB0Ukl25+rVV1LXAbsBoXDEqBT+j+1xtavrbten9Ll6CQVkQkD3geuFZVy+LXqeuD3G36IYvIycAmVf0k1WnpYAFgf+BeVR0PVNKkqqi7XWsArx79NFxQHAzksm01S7eXzGubLkFhLTAs7vVQb1m3IyJBXEB4XFVf8BZvrCtOer83pSp9SXAYcKqIrMRVCx6Nq2vv5VUvQPe83oVAoarO8V4/hwsS3flaAxwLfKOqRaoaBl7AfQe6+/WGlq9tu97f0iUozAVGeT0UMnANU9NSnKZ259WlPwQsVtXb41ZNAy72/r4YeLmj05YsqnqDqg5V1RG46/qOqp4PzAS+523Wrc4ZQFU3AGtEZLS36BhgEd34WntWAweLSI73fa877259vT0tXdtpwEVeL6SDgdK4aqbtljZPNIvIibi6Zz8wVVVvSXGS2p2IHA58AHxBQ/36r3HtCs8Aw3HDjk9W1aaNWF2eiBwJ/EJVTxaRXXElhz7AfOACVa1NZfram4iMwzWuZwArgEtxGb1ufa1F5PfA2bjedvOBH+Lq0LvN9RaRJ4EjccNjbwRuAl6imWvrBce7cdVoVcClqjpvh4+dLkHBGGNM29Kl+sgYY0wCLCgYY4ypZ0HBGGNMPQsKxhhj6llQMMYYU8+CgjEdSESOrBvJ1ZjOyIKCMcaYehYUjGmGiFwgIh+LyAIRud+br6FCRP7ujeX/toj087YdJyKzvbHsX4wb5353EZkhIp+JyKcispu3+7y4eRAe9x4+MqZTsKBgTBMiMgb3xOxhqjoOiALn4wZfm6eqewHv4Z4yBfg38CtV3Rf3NHnd8seBe1R1P+BQ3Kie4EavvRY3t8euuLF7jOkUAm1vYkzaOQY4AJjrZeKzcYOPxYCnvW3+A7zgzWvQS1Xf85Y/CjwrIvnAEFV9EUBVawC8/X2sqoXe6wXACODD5J+WMW2zoGDMtgR4VFVvaLRQ5LdNttvRMWLix+SJYv+HphOx6iNjtvU28D0R6Q/1c+Pugvt/qRuJ8zzgQ1UtBbaKyLe85RcC73kz3xWKyOnePjJFJKdDz8KYHWA5FGOaUNVFIvJ/wJsi4gPCwI9xE9lM9NZtwrU7gBvG+D7vpl83Wim4AHG/iNzs7eOsDjwNY3aIjZJqTIJEpEJV81KdDmOSyaqPjDHG1LOSgjHGmHpWUjDGGFPPgoIxxph6FhSMMcbUs6BgjDGmngUFY4wx9f4/zuy3grJ/hK8AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(trained_model.history['acc'])\n",
+    "plt.plot(trained_model.history['val_acc'])\n",
+    "plt.title('model accuracy')\n",
+    "plt.ylabel('accuracy')\n",
+    "plt.xlabel('epoch')\n",
+    "plt.legend(['train', 'test'], loc='upper left')\n",
+    "\n",
+    "print(np.max(trained_model.history['acc']))\n",
+    "print(np.max(trained_model.history['val_acc']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.3663262344896793\n",
+      "0.7790719392895699\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3XeYVOX58PHvPbOzvbAsS9sFQQVFqoJdE9SoiDWxlyQmKprXJPpLYtQkxhYTjYktQREjlqgYYyUqgoViQQURld6kLHVZ2N5mZ+73j2e2sGyZXXZ2YOf+XBfX7JzzzDnPmTOc+zz1iKpijDHGAHiinQFjjDH7DgsKxhhj6lhQMMYYU8eCgjHGmDoWFIwxxtSxoGCMMaaOBQVjwiQiT4vIn8JMu05Evre32zGms1lQMMYYU8eCgjHGmDoWFEyXEqq2uUlEvhaRMhF5UkR6ich0ESkRkfdEJLNB+nNEZImIFIrIbBEZ0mDd4SKyMPS5/wCJjfZ1logsCn32ExEZ0c48XyMiq0Vkp4hME5G+oeUiIg+KyHYRKRaRb0RkWGjdeBFZGsrbJhH5Tbu+MGMasaBguqLzgVOBwcDZwHTgd0A27jf/SwARGQxMBW4MrXsb+J+IxItIPPA68G+gO/Df0HYJffZwYApwLZAFPA5ME5GEtmRURE4G/gJcBPQB1gMvhlafBnwndBwZoTQFoXVPAteqahowDPigLfs1pjkWFExX9A9V3aaqm4APgc9U9UtVrQReAw4PpbsYeEtV31VVP/A3IAk4DjgG8AEPqapfVV8G5jfYxwTgcVX9TFUDqvoMUBX6XFtcDkxR1YWqWgXcChwrIgMAP5AGHAqIqi5T1S2hz/mBw0QkXVV3qerCNu7XmCZZUDBd0bYGf1c08T419Hdf3J05AKoaBDYCOaF1m3T3GSPXN/j7AODXoaqjQhEpBPqFPtcWjfNQiisN5KjqB8A/gYnAdhGZLCLpoaTnA+OB9SIyR0SObeN+jWmSBQUTyzbjLu6Aq8PHXdg3AVuAnNCyWv0b/L0RuEdVuzX4l6yqU/cyDym46qhNAKr6iKqOBg7DVSPdFFo+X1XPBXriqrleauN+jWmSBQUTy14CzhSRU0TEB/waVwX0CTAPqAF+KSI+EfkBcFSDzz4BXCciR4cahFNE5EwRSWtjHqYCPxGRUaH2iD/jqrvWiciRoe37gDKgEgiG2jwuF5GMULVXMRDci+/BmDoWFEzMUtUVwBXAP4AduEbps1W1WlWrgR8AVwI7ce0Przb47ALgGlz1zi5gdShtW/PwHnAb8AqudHIQcElodTou+OzCVTEVAPeH1v0QWCcixcB1uLYJY/aa2EN2jDHG1LKSgjHGmDoWFIwxxtSxoGCMMaaOBQVjjDF14qKdgbbq0aOHDhgwINrZMMaY/coXX3yxQ1WzW0u33wWFAQMGsGDBgmhnwxhj9isisr71VFZ9ZIwxpgELCsYYY+pYUDDGGFNnv2tTaIrf7ycvL4/KyspoZyXiEhMTyc3NxefzRTsrxpguqEsEhby8PNLS0hgwYAC7T2rZtagqBQUF5OXlMXDgwGhnxxjTBXWJ6qPKykqysrK6dEAAEBGysrJiokRkjImOLhEUgC4fEGrFynEaY6KjywSFNlGFsh3u1RhjTJ3YDApVJVC0EapLO2RzhYWFPProo23+3Pjx4yksLOyQPBhjTEeIzaAQqA69+jtkc80FhZqamhY/9/bbb9OtW7cOyYMxxnSELtH7qM1qg0Gw5Yt2uG655RbWrFnDqFGj8Pl8JCYmkpmZyfLly1m5ciXnnXceGzdupLKykhtuuIEJEyYA9VN2lJaWcsYZZ3DCCSfwySefkJOTwxtvvEFSUlKH5M8YY8LV5YLCnf9bwtLNxS0nqql0AcFbDN41rW7zsL7p3H720GbX33vvvSxevJhFixYxe/ZszjzzTBYvXlzXbXTKlCl0796diooKjjzySM4//3yysrJ228aqVauYOnUqTzzxBBdddBGvvPIKV1xxResHbIwxHShi1UciMkVEtovI4mbWZ4jI/0TkKxFZIiI/iVRe9lDbwByhhuajjjpqt3EEjzzyCCNHjuSYY45h48aNrFq1ao/PDBw4kFGjRgEwevRo1q1bF5G8GWNMSyJZUnga91DzZ5tZfz2wVFXPFpFsYIWIPB96YHq7tXRHX2f7MldaSMyA7gfuze6alJKSUvf37Nmzee+995g3bx7JycmMHTu2yXEGCQkJdX97vV4qKio6PF/GGNOaiJUUVHUusLOlJECauI73qaG0HVPJ35oOblNIS0ujpKSkyXVFRUVkZmaSnJzM8uXL+fTTTztkn8YYEwnRbFP4JzAN2AykARerarCphCIyAZgA0L9//73bazAAGgj93TFBISsri+OPP55hw4aRlJREr1696taNGzeOSZMmMWTIEA455BCOOeaYDtmnMcZEgmgEB3CJyADgTVUd1sS6C4DjgV8BBwHvAiNVtcVW4jFjxmjjh+wsW7aMIUOGhJcpfyXkLwPxuvd9RoT3uX1Im47XGGMAEflCVce0li6a4xR+AryqzmrgW+DQiO+1doyCL8mVGGxUszHG1IlmUNgAnAIgIr2AQ4C1Ed9rMNSe4EsOve+cZgxjjNkfRKxNQUSmAmOBHiKSB9wO+ABUdRJwN/C0iHwDCHCzqu6IVH7q1DYy+0IDw4I14LVnExhjDEQwKKjqpa2s3wycFqn9NytQDZ64+kBgJQVjjKkTe3MfBfzg8bnAABYUjDGmgdgMCl4LCsYY05TYCwpBP3jj64NCYO+DQnunzgZ46KGHKC8v3+s8GGNMR4itoBAM1jcsi7ixCh1QUrCgYIzpKrrcLKktqu2OWtvI7InrkKDQcOrsU089lZ49e/LSSy9RVVXF97//fe68807Kysq46KKLyMvLIxAIcNttt7Ft2zY2b97MSSedRI8ePZg1a9Ze58UYY/ZG1wsK02+Brd80vU5rwF8BcUkuIPhDd+i1Yxaa03s4nHFvs6sbTp09c+ZMXn75ZT7//HNUlXPOOYe5c+eSn59P3759eeuttwA3J1JGRgYPPPAAs2bNokePHu05WmOM6VCxVX1UO3pZQoctgpuXr+PMnDmTmTNncvjhh3PEEUewfPlyVq1axfDhw3n33Xe5+eab+fDDD8nIyOjQ/RpjTEfoeiWFFu7oKdkGJZuh9wjweKFwA1QWuZJAB1FVbr31Vq699to91i1cuJC3336bP/zhD5xyyin88Y9/7LD9GmNMR4itkkLQ7xqXPaHJ8GrbFPZy/qOGU2effvrpTJkyhdLSUgA2bdrE9u3b2bx5M8nJyVxxxRXcdNNNLFy4cI/PGmNMtHW9kkJLAtW7T2lRN1YhAN72fxUNp84+44wzuOyyyzj22GMBSE1N5bnnnmP16tXcdNNNeDwefD4fjz32GAATJkxg3Lhx9O3b1xqajTFRF9GpsyNhr6bOzl/hSglZB7v35TuhcD1kDwFfYgRyGxk2dbYxpq32h6mzO1/tFBe1bFSzMcbsJnaCggbrRzPX8lpQMMaYhrpMUGi1Gqx2Oosm2xT8kclUBOxv1X3GmP1LlwgKiYmJFBQUtHzBbDyaGXZvaN4PqCoFBQUkJu4/7R/GmP1Ll+h9lJubS15eHvn5+c0n8pdD2Q7Y6dm9CqloB8RXQNKuyGe0AyQmJpKbmxvtbBhjuqguERR8Ph8DBw5sOVHhBvh2OQw6HhJS65c/cjn0GQkXPhXZTBpjzH4gYtVHIjJFRLaLyOIW0owVkUUiskRE5kQqLwB06w+HX757QABI6QHlkX8KqDHG7A8i2abwNDCuuZUi0g14FDhHVYcCF0YwL81L7gFlBVHZtTHG7GsiFhRUdS6ws4UklwGvquqGUPrtkcpLi1KyrKRgjDEh0ex9NBjIFJHZIvKFiPwoKrlI7gHlBXs9/5ExxnQF0WxojgNGA6cAScA8EflUVVc2TigiE4AJAP379+/YXKT0cIPXKgshKbNjt22MMfuZaJYU8oAZqlqmqjuAucDIphKq6mRVHaOqY7Kzszs2F8mhh9vUtivUVHXs9o0xZj8SzaDwBnCCiMSJSDJwNLAsUjubv24nVz+zgK1FlbuvSMlyr3Pvh8e/A3/qCStnRiobxhizT4tkl9SpwDzgEBHJE5GrROQ6EbkOQFWXAe8AXwOfA/9S1Wa7r+6tnWXVvLdsGztKG5UEMvq516//U/9Etp1rI5UNY4zZp0WsTUFVLw0jzf3A/ZHKQ0NpCe5Qy6oaTX6XfQhc9R50HwjxqXBPL6gu7YwsGWPMPqdLjGgOR2qiO9TSxkEBoN+R7lXVPZnNX96JOTPGmH1Hl5gQLxypCS0EhVoiEJ8C1WWdlCtjjNm3xE5QCJUUSipbeXaCBQVjTAyLmaCQluCmzG6xpADgS7agYIyJWTETFBJ9HrweoTSckoK1KRhjYlTMBAURITUhrvWSQnyqlRSMMTErZoICuMbm1tsUrPrIGBO7Yi4olFa18jxma2g2xsSw2AoKiWFUH/ksKBhjYldsBYWEOEqrAi0nik8BvwUFY0xsiq2gkBhHaWVr1UfWpmCMiV0xFRTSwu19FKiGQCvBwxhjuqCYCgqpCXGtj1PwJbtXKy0YY2JQbAWFxDjKqgMEgi08ejM+xb3aADZjTAyKraBQO312dQulhfhU92olBWNMDIqpoJBWO312S1VI8VZ9ZIyJXTEVFFLDmRSvtvrIgoIxJgbFVlAIZ/psnwUFY0zsiuQzmqeIyHYRafG5yyJypIjUiMgFkcpLrdQELxBmScEGsBljYlAkSwpPA+NaSiAiXuA+YGYE81Gntvpoj+c0N2RtCsaYGBaxoKCqc4GdrST7BfAKsD1S+WgoNayG5treR9Yl1RgTe6LWpiAiOcD3gcfCSDtBRBaIyIL8/Px277O2S2pJSyWFusFrpe3ejzHG7K+i2dD8EHCzqgZbS6iqk1V1jKqOyc7ObvcOa4NCiyUFXxIgNnjNGBOT4qK47zHAiyIC0AMYLyI1qvp6pHbo9QjJ8d6Wn6kgYk9fM8bErKgFBVUdWPu3iDwNvBnJgFArvEdy2kypxpjYFLGgICJTgbFADxHJA24HfACqOilS+21NamI4j+S0B+0YY2JTxIKCql7ahrRXRiofjYU1fbY9fc0YE6NiakQz1D5oJ4ySgg1eM8bEoJgLCinx1qZgjDHNibmgkJoYTlBIscFrxpiYFHNBwdoUjDGmeTEXFGrbFFRbefqatSkYY2JQ7AWFBB81QaWqpoWB1NYl1RgTo2IvKITzTIX4FKiphGCgk3JljDH7hpgLCmm18x/Z09eMMWYPMRcUwpsUz56pYIyJTbEXFGqrj1qaFK/2mQo2U6oxJsbEXlAIp6QQb89UMMbEppgLCmmJbWlTsJKCMSa2xFxQSAmnodlnDc3GmNgUc0EhtS29j2wAmzEmxsRcUEiI8+DzSphtChYUjDGxJeaCgoi0/vS12t5HFhSMMTEm5oIChPFMBRu8ZoyJUbEZFBJ8lLRUUohLcq8WFIwxMSZiQUFEpojIdhFZ3Mz6y0XkaxH5RkQ+EZGRkcpLY2kJrZQUPB7XA8kGrxljYkwkSwpPA+NaWP8t8F1VHQ7cDUyOYF52E96DdpJt8JoxJuZELCio6lxgZwvrP1HVXaG3nwK5kcpLY602NIM9fc0YE5P2lTaFq4Dpza0UkQkiskBEFuTn5+/1zlIT41qeOhvs6WvGmJgU9aAgIifhgsLNzaVR1cmqOkZVx2RnZ+/1Pt0jOVuYEA/s6WvGmJgU1aAgIiOAfwHnqmpBZ+03JSGOSn+QmkBLT19LtpKCMSbmRC0oiEh/4FXgh6q6sjP3XTvVRVlVC09Wi0+1NgVjTMyJi9SGRWQqMBboISJ5wO2AD0BVJwF/BLKAR0UEoEZVx0QqPw01fKZCRrKv6UTxKdb7yBgTcyIWFFT10lbWXw1cHan9tySsR3L6rPrIGBN7wqo+EpEbRCRdnCdFZKGInBbpzEVKbUmhuKKVqS5s8JoxJsaE26bwU1UtBk4DMoEfAvdGLFcR1icjEYAtRRXNJ6oNCsEWGqONMaaLCTcoSOh1PPBvVV3SYNl+J6ebmxo7b1crQQGstGCMiSnhBoUvRGQmLijMEJE0YL+9hU6K99IjNb7loOCzZyoYY2JPuA3NVwGjgLWqWi4i3YGfRC5bkZeTmUzerhZKAbXPVLABbMaYGBJuSeFYYIWqForIFcAfgKLIZSvycjOT2NRi9ZGVFIwxsSfcoPAYUB6a3vrXwBrg2YjlqhPkZiaRV1hBMKhNJ6h70I61KRhjYke4QaFGVRU4F/inqk4E0iKXrcjLzUymuibIjtKqphPUPZKz1JUWXrgElrzeeRk0xpgoCDcolIjIrbiuqG+JiIfQ6OT9VW6me7raxuaqkBo2NE/7BaycDl+92Em5M8aY6Ag3KFwMVOHGK2zFPfvg/ojlqhP0CwWFZhuba6uPPnkEFr8CyVmQ9zloM9VNxhjTBYQVFEKB4HkgQ0TOAipVdb9uU2h1rEJtUMibD0POgZN+D+UFsHNtJ+XQGGM6X7jTXFwEfA5cCFwEfCYiF0QyY5FWP1ahuZJCqE2hxyFw3qPQ72j3Pm9+52TQGGOiINxxCr8HjlTV7QAikg28B7wcqYx1BjdWoZmSQkIqnDcJBhwPCWnQcwjEp8HGz2HkJZ2bUWOM6SThBgVPbUAIKWAfeGrb3srNTGLp5uLmE4xqMNGrxws5R7h2BWOM6aLCvbC/IyIzRORKEbkSeAt4O3LZ6hy1A9iaHavQWL+jYdsSqLLnLBhjuqZwG5pvAiYDI0L/Jqtqs89U3l/kZiZTHQiS39xYhcb6HQUahM0LI5sxY4yJkrAfsqOqrwCvRDAvnS63QbfUXumJYXwg9GC4jZ/DwO9EMGfGGBMdLZYURKRERIqb+FciIi1UxoOITBGR7SKyuJn1IiKPiMhqEflaRI7YmwNpj/qxCi3MgdRQUib0GGw9kIwxXVaLQUFV01Q1vYl/aaqa3sq2nwbGtbD+DGBQ6N8E3PxKnSqs5yo0lnuUCwo2iM0Y0wVFrAeRqs4FdraQ5FzgWXU+BbqJSJ9I5acprY5VaEq/I20QmzGmy4pmt9IcYGOD93mhZXsQkQkiskBEFuTn53dsJloaq9CU3KPc60brmmqM6Xr2i7EGqjpZVceo6pjs7OwO3XZuZlLbgkL2oZCQAWtndWg+jDFmXxDNoLAJ6NfgfW5oWadq81gFj8cNavvmZatCMsZ0OdEMCtOAH4V6IR0DFKnqls7ORJvHKgCc8H/g9cHcv0UuY8YYEwURCwoiMhWYBxwiInkicpWIXCci14WSvA2sBVYDTwD/L1J5aUlua1NoNyWtN4y5yj1foWBNhHJmjIlJlcVR7d0Yyd5Hl6pqH1X1qWquqj6pqpNUdVJovarq9ap6kKoOV9UFkcpLSw7o7rqlrslv47OYT7gRvPEw568RyJUxJiYVbYK/DYJl/4taFvaLhuZIGpCVQnK8t+WJ8ZqS2hOOuhq+eQl2rIpM5owxsWXtLKiphHUfRS0LYU9z0VV5PMJhfdJZvKmo7R8+7gaY/yQ8djwkprtnMAy/AE7+Q8dn1BjT9a2d4163fh21LMR8SQFgWE4GS7cUEwi3B1Kt1Gy47CU4egIcepabBuOjh6BkW2QyaozpulTh27nu763fQDAYlWxYUACG9k2nvDrAuoI2tisADDwRTvsTnP0QnP8vCPph4TMdn0ljTNe2YyWUboXcI6G6NGpd3i0oAEP7ZgC0rwqpoayD4KBTYMEUCPg7IGfGmJhRW0o47hfudetXUcmGBQVgUK9U4r0elrS1sbkpR10DJVtg+Vt7v63GVGHlDPBXNp8mGIT/XAFfPt/x+zfGRM7a2ZDRHwafAR4fbIlOu4IFBcDn9XBonzSWbN7LkgLAoNOgW3/4/Im2fa50O3z8MARqmk+z6Hl44SKY98/m0yx/03VnW/Bk2/a/vwvUdO6YkYC/5XNl9k3lO+GBoVHt8tmkYMD1ODrwOxAXDz0PjVpjswWFkKF901m8qRjd20EjHq8b2Lb+I/foznC9ezu8+0dYNq3p9SXbYMbv3d8Ln2m6EUq1ftzEpoXuP0CsmPtX+OeYPe+uqkrg00lQU92x+3v+Avjvjzt2mwa+fsndHEXKsmlQnAefduJM/f4w5lbb+jVUFsLAse5975HutxyFQWwWFEKG9s2gqMLftsnxmnPEjyAuEebcF96FOX8FfP2i+/vzyU2needm8JfD2FuhcEPTE/KtmA7bvoExPwXUFUdjQVUpfPa4e1Tq+3fuvu7dP7rvbsmrHbe/LV+773blO7EVeCOtuhym/9bdIG1fHpl9fPOye13/cec05C78N/wl1/VKbKk3UW1X1IEnutc+I6F8BxRvjnweG7GgEDIsxzU2d0gVUnJ3OPJqWPoG/G0wvHg5fPth8+ln/wV8yW5OpQ3zYEujBqblb8OS1+C7v3VpkrPgi6d2T6PqglDmABh3LyRmwJoP9v5YImHXOqjsgO+51pf/dndZQ38Aq9+r/w+2cT4sCH1PX7+0+2dUYdV7UN2OHmfz/wXigWCNa+PpKFsXw9TLoCiv47a5P/lqKlTsAk+c+y13tJKtrorm8B+687doasfvoyFVd7MiXnjvdnju+y4PTfl2rpuBOa23e99nhHuNQhWSBYWQQ3un4fVIxzQ2A5x+D1z3ERx9rXtS23M/aPrOZMvX7oJ/zM/g+BtdcPisQWmhfCe89WvoOdQNlotLgFGXuVJBwx/YqndhyyI48TcuzcDvuqCwrz0h7otn4B+j4YHD4J1bXYDYGwE/zJsI/Y+F8x6DjH6udFBTDW/eCOl94ahr3Z196fb6z618B54/3323bVFRCN/8F0ZeBum5HVc3vWud+42seKs+kO3Lqkpg+s27f6d7Ixh0VTp9D3e9b5a8BtuXdcy2ay15DVA47pdw4EkuCEVyLMCWRa7kfvo9cPYjsOEzN9C1cMPu6Wqq3c1gw+e+9xoGSFQamy0ohCT6vBycnbr33VIb6j3c/SAmzHG9Cd79455pZt3j7uqP/TkkdYMRF7uLTlmB+4/3/AWuGHnuP1wDFMARV7q71EWhHkZlBfDB3a6Be+QlbtnBp0DxJtf3uTVVJW7OlUgKBuCd38H/fgkDToRDxruqskcOd3X+7bXkdSjaCMffAL5EOOn37j/j8xfAtsVwxl9hzE9AA6GLAi5QfvgAIO7CsPr98Pf31VRXjXfUNTDkLFjzvqu+2htlO+DfP3DTG/Qe7ko1nTFwaeN8mPdo+z775XPw2SQXkMPe3+dQuLHpdavfhYJVcMz1LijEp8Lse9uXt+YsfsV9v9mD3Y1V0UZYN7dj99HQwn+7auThF8LoH8OEWe63M/3mRumeccsPOqV+WUKq6+JuJYXoGpqTzuKOKik0lN4HTvw/d1fZsBpp7Rx3x3rcL11AAFeyCFS5/3AvXAKbF8GFz0DO6PrP9TjYXVi/eAYWveAaWLcvhVPvclN6Axx0sntt7YJXshUe/y48dqy7OLWVKuS3Enj8FfDiZfDpRHfXfvnLcP4TcMPX0P84mHOvq09uz74/fhh6DIZBp7tlIy5yd1nfznGBZ8hZ0HMI9BpeX4W0YR7kfQ6n3Q1Zg1yJIpwLu6qrOso9EvqOgiFnuwv56vfCz3PRJlev/cE9rlPAxw/Dc+e7AH7ZS3DsL6Bog8tjQyXb9iz1BYPw2s9gcTvbSz64C2bc6qonG9q13gWL5sbaqLqxOOCCQ00Y086X5sPTZ8HT410VUWPzJkJaXxh6nqt+PfpaWPp62zprtGTXOldiH3a+e3/oWe5hWYte6JjtN+avcOd5yDn1/7d7DoHv3gwr3q7vsr5jNcy8zQWEwafvvo0+I62kEG3D+maQX1LF9uIWxgG017E/d1UbM251d81LXnfdSzMHwtHX1afrOcQVI+f+1TWG/WAyHDp+z+2NvhIK18PrP4Osg+HaD2Ho9+vXd+vvLngttSuU7YBnz3WBoboM3r+r7cf16aMw8Uj46j9Nr68uhxcudnXv4/8G4/8K3tCUWxk5cNKt7iLxTaM6/4pCd2c34/fw1Jnw8lVuWUMr3nbF8+N+6R5+BK731/j73WNTz2hQLz38Ati0wHVb/egh1y4z5io45xFXnJ91T+vHunY2FKx27UXgqqySe+xeheSvdPtoeKefv8KVkh4cDg8eBq9c5c7vrHtc6TF/OVz4NPQ/xgUxX0p9xwNw1Q4PDNlzRt5l0+CrF1xQa2uDd1kBrPvY/f32TfVBsbIYnr/Q/U5fuarpbrfrPnQl0OEXulJsw+OvKoGXfrxnG9oXT7ubneLNLpA1/H62LnZB/Khr6m9qjr0eEtJh1p/bdlzNWfyKex36A/fqS4Th58PSaa59q6rUnbeO6qW2dBpUFblOJw0dez1kD3GlhcoieG2Cq+49dyKI7J629wh3g9DJnRksKDQwtG86AIs7orG5MV8SnHqnm9PkhYtdd8Y+I+Hq91xRsaHjbnDVTWc/7C5mTRlytqtqOvMB+OkM6HXYnmkOOtk1rDU12K18Jzx7nrsrvPwldwe/8FnXlTVc25fBe6HePnPu3fMCUl3mAt+3c119/1HX7LmNA453d/GfPV5/J+yvgCmnw8s/deM9/OWu0f7JU127jKq7s3zpRy7wjbio0TaPg6vfdYGx1vALAHGBb9UMOPpnEJ/s0o65ytVnb/i06eMMBt0xvH+XCyaHneeWe7wuYK+c4e6Wd62Hx0+EfxwB9/Z3wezJ02DiUa6qrM8IGHcfTJgNtxW4f7/bDDevg0POcNuMT4HDzoElb7jzVlPtqtw0AB8/BMVb6vM05z7XrlFV6jortMWKt902x//NddGc9We3zdd/5gLfET9y3/lr17qbmIYWTIHEbu73mTmgvtQA7vew9HWX59oLbE21K2Ed/D047R5YOR0+ecSt2/K163HkS3Y3OrWSu7tgv/xNd4FtqCjPlfqaai9rrg1t8avuRiHzgPplo66AmgrXGeQvOe68Tf9ty9/boqkukLfWUeLLf7sbvgEn7L7c64OzHnRVV5NPgk1fuCly0vvsuY0oNTZbUGhgaE4GXo/wxfomirf/kCxLAAAc90lEQVQdsoMfQL+jXf3psPPhR9Mgpcee6QZ9D27d6OohmxOX4EoRR15Vf5fc2MGnuB/9xkYXu4I18NR4d7d36Qvuhzv2ZkjJdncw4dRn11TDqxMgIc1dHHau3f1u31/hgl9taWfUpU1vRwSOuc5Vf9UO83/vzvq751vzXF3sj16Hsnx44hTXXjDjdzB4nAuqcQmt5zcj1wWgpa+7O/Ejr6pf97073MXixctccb5WoAY+/Ds8NByeOdtNkf69O91dZq0h50B1ibvIPXkqlG6D0//s2nZqKt0F+9S74FfL4JLn3bH2PdyVlrxxLgj4knbP64iL3V3myunwycPuuzjjr64dadafXJpl00JVhne6Lsjzn2xbN85l01zQPPJq9/nPHoPXr3MX4dP+BOf8w30vi1+GN66vr0oq2eZKBqMud3kf/RN3jrcvg/WfwPwnoN8x7vcw/1/1+yrd6krER1/rgur7d8GUcS6Ibl7kvqPk7rvn8YQb3Y3TmzfWN2iXbIWnz4RXr9lzEOeiqfDXA11DfW1wUIWPHnTtS41vsHKOgO/8Fo74sTvWQ8a76rDm2tcCNTDzD67K759HuuqhpoLQzrWuNHX4FXve/QMccKwLSDvXwPCLdi/hN9R7pHvtyB5u4VDV/erf6NGjNZLOm/iRfn/iR5HbQeFG1a9eUg0GI7ePWpUlqndmqT5zrur6T1UDAdXlb6v+OVf13gGqa2bvnn7hc6q3p6t++cKe29q1XnXOX1WXvKFamq/6/t0u7dJp7lgmnaj60EjVGr/798KlqrdnuGNtTXWF6n0DVV+4RHXNLLfdt27aM92O1aoPH656Z3fVTya2/Ttc8JTb9ju/a3rb9x2o+uAw1eKt7t+U8S79s+epfv1f1aqyPT/nr3Tf5+3pqg8MVd22rG15akqgRvVvh6g+/l3Vu7JV//Mjt/yd37nvdPNXqhOPUf3HGJe2dIfqX/qp/vsHTW/rk4mq86fUL6soVL2rR/33UL5L9f5B7hheuWb373X2X93yJ75X/xu4PV01f6VbX5rvtvXGz925eXC4alWp+839pb9qWYHq5JNVHznC/f5UVSuKVP9xpOrfDlX98EG3/+ZsW+a+g+cvVi3fqTrxWNU/9VF96kzVO7qprv7ApVs+XfWOTPc93J6u+trP3L7/+1P3/qUr3e+sJTvXuW1Mv6Xp9avec9ua9Rd3bm5PV33uAvcd1Crf6X43d2SqFm1qfl/lO1Xn/t2di5a8fr3b1qYvW04XBmCBhnGNFd3Xuiy2YsyYMbpgQeQe0nb/jOVMmrOWr24/jdSELvC4iVl/dnXogSpI6+PmZeozEi5+bvfqFXAlhNoqmh//D3oPc8tLt7vljbuPjrwMvh8aGbpiOky9xNWN5s13dchn3O+mFQ/H+3e7u/LUnq4u+dq5rnqnsapSKC/YvRogXNVlrkfL8Tc0XULb9IVrDO12AFTsdPXrZz9U36OrOTNvg7wFcMGUpqsB2mPmba70kZABP//c9V+v2AUPj3Ili5ItcP6T9Xe/8x517QBnPQQjL3WlmaI8V5pb/zEg8JPp7i716//Cq1fDT2dC/6Pd59fOdne+4+/fs+TyzcvwvxtdidQb79q9ftygHeGVq12POYAfvQEHjnXtBJNOcO1j387Z87cQ8LuxAh5v69/FvImuZJie60pil//XNfb/63vu/Rl/hWm/gOxD4MfTXPo594E3AQLVcMptcMKvmr5rb+y161y12Y2LISVr93WvX+/W3bTaVQN9/oSrSkrOcqXa9D6uPaZgjasuHXFh6/trTcUu+OdR7vxfM6u+Pa4dROQLVR3TasJwIkd7/wHjgBW45zDf0sT6/sAs4Evga2B8a9uMdEnho1X5esDNb+oHy7ZFdD+dqqJIddFUd/c+/RbV6vLm0+avUv37EHfHteEz1cpiVwr4U2/VdR+7Esfcv6v+78bd73KCQXf3dHdPdwf17h1ty2PRZlcCuCNTNW9Be46yY6x81+XjkSNUty6JXj62LXP5+OKZ3Zd/8k/3/daWEmr5q1QfPd6tu6ev6tTL3Dm8p68rJTw4XPXhUe4u/sXLVe8fXH/nHo4dq1Unfcdtf/Fru69b94lb/sYvdl/++vVu+Z9z3e+ovQKBUKktY/d971it+udQyeDhw3e/Y18xQ/Xxsa5k3Bbblrntvf+n3Zf7K92+Xr129+WbF7kS8p3dXWn3z/1U185p2z5bs/g1l6ePHtqrzRBmSSGSAcELrAEOBOKBr4DDGqWZDPws9PdhwLrWthvpoFBRXaODfve23vPW0ojuZ5+2a727gPypt/uPdUem6sqZrX9uxQz34331uvZVj302WXXRi23/XEfbsdpdPKOtqaoFf6Xqf36ouurdptetfFd12i9d9dOT41QL1rh1334YunD/XPXuXqpv/qrt+fFXqn77UdPnds3sPatnire4gDDj923fV2OVxapbvtlz+ar3VJ8+21X9dJTagNowkC17031/K5v43isKVV/6sQtM2yJw3QgGXZ7u7ul+m+0UblCIWPWRiBwL3KGqp4fe3xoqmfylQZrHgbWqel8o/d9V9biWthvp6iOAix+fR1l1DW/+4sSI7mefVrLNjbDdthjOm9R8Q3Fj25e5cQPhVAuYzjX9Zjf+BVwnhwO/G/l9lu90nRFqu5ruDzZ9AU+c7MYUnPQ7t+zln7oqtl+vaP5YVMOromqP4s0w8WjX0+7Mv7drE+FWH0Wy0jwHaDh8MQ84ulGaO4CZIvILIAX4XlMbEpEJwASA/v37N5WkQx13UA8een8lheXVdEuOj/j+9klpveCn77juiX0PD/9zPYdELk9m75zyR9eTparY9cTqDI17FO0Pcka73oFz7nM9246+zrWZjbyk5eAWqYAAbrqWK9/qlP9f0e6SeinwtKrmAuOBf4vIHnlS1cmqOkZVx2RnZ0c8U8cdnIUqfPZtjM+AmZDWtoBg9m3xKa4h+Iev7VWDZUz4/uOuu+j7d7kpSPzlMKyZMUOdpc+ITilxRTIobAL6NXifG1rW0FXASwCqOg9IBJroFtK5RuZ2I8nnZd6agmhnxZiOlXmA631mWub1ucBw1AQ3zietrxvBHgMiebswHxgkIgNxweAS4LJGaTYApwBPi8gQXFDIj2CewhIf52HMgEw+WdOOuYCMMV2Dx+O6u2Yf6rpzNzdItIuJ2FGqag3wc2AGsAx4SVWXiMhdInJOKNmvgWtE5CtgKnClRqrlu42OO6gHK7eVkl8SxmRfxpiuScSNfm9q/rEuKqIVi6r6NvB2o2V/bPD3UqCTWrza5tiD3MCVeWsLOGdk3yjnxhhjOkdslIfaYVjfdLol+/hg2bZoZ8UYYzqNBYVmxHk9nDqkF+8v205VTaD1DxhjTBdgQaEFZwzvTUlVDZ+stl5IxpjYYEGhBccf3IO0hDjeWdzMw7aNMaaLsaDQgoQ4LycP6cnMpVupCXTCM3ONMSbKLCi04oxhvdlV7ufzWB/dbIyJCRYUWvHdwT1J8nmZblVIxpgYYEGhFUnxXsYeks2MJVsJBveJcXXGGBMxFhTCMG5Yb7aXVLFwQ4Se3WyMMfsICwphOPnQnsTHeXj1y2Ye6G2MMV2EBYUwpCX6OP+IHF7+Io/tJZXRzo4xxkSMBYUwXfudg6gJBHnyo2+jnRVjjIkYCwphGtAjhbNG9OW5eespKvdHOzvGGBMRFhTa4GdjD6KsOsAz89ZFOyvGGBMRFhTaYEifdE45tCdPffwt5dU10c6OMcZ0OAsKbfT/TjqYXeV+XvhsQ7SzYowxHc6CQhuNPiCT4w7KYtKctVZaMMZ0ORYU2uFXpw5mR2kVz85bH+2sGGNMh4poUBCRcSKyQkRWi8gtzaS5SESWisgSEXkhkvnpKGMGdOe7g7N5fM4aSqustGCM6ToiFhRExAtMBM4ADgMuFZHDGqUZBNwKHK+qQ4EbI5Wfjvbr0wazq9zPUzZuwRjThUSypHAUsFpV16pqNfAicG6jNNcAE1V1F4Cqbo9gfjrUiNxunHpYLyZ/uNbGLRhjuoxIBoUcYGOD93mhZQ0NBgaLyMci8qmIjGtqQyIyQUQWiMiC/Pz8CGW37X516mBKKmt4dM7qaGfFGGM6RLQbmuOAQcBY4FLgCRHp1jiRqk5W1TGqOiY7O7uTs9i8IX3SuWhMLpPnrmXuyn0nWBljTHtFMihsAvo1eJ8bWtZQHjBNVf2q+i2wEhck9ht3nDOUwT3TuOHFL8nbVR7t7BhjzF6JZFCYDwwSkYEiEg9cAkxrlOZ1XCkBEemBq05aG8E8dbjk+Dgm/XA0NQHl+ucXUlUTiHaWjDGm3SIWFFS1Bvg5MANYBrykqktE5C4ROSeUbAZQICJLgVnATapaEKk8RcrAHincf+FIvsor4q7/LY12dowxpt1Edf96xOSYMWN0wYIF0c5Gk/7y9jIen7uWiZcdwZkj+kQ7O8YYU0dEvlDVMa2li3ZDc5fym9MPYVS/btzy6tds3GntC8aY/Y8FhQ7k83r4x6WHg8Ivpn6JPxCMdpaMMaZNLCh0sH7dk7n3/BEs2ljIX95ezv5WPWeMiW1x0c5AV3TmiD58/u0BTPn4W4or/fz5+8OJj7P4a4zZ91lQiJA7zhlKt+R4Hn5/FRt3ljPpitFkpsRHO1vGGNMiu32NEBHh/04dzMOXjOLLDYWc9+jHLN5UFO1sGWNMiywoRNi5o3KYOuEYqvxBfvDoJ/z70/XWzmCM2WdZUOgEow/I5O0bTuTYg7K47fXF/Oy5hWwosC6rxph9jwWFTtI9JZ6nrjyS3447hFkrtnPy32fzu9e+YUtRRbSzZowxdSwodCKPR/h/Yw9m7m9P4rKj+/PfBRsZe/9sJs1ZY2MajDH7BAsKUdArPZG7zh3GB78ey9hDsrl3+nLO+efHfLWxMNpZM8bEOJv7aB/wzuKt3D5tMduKqxjSJ53TDuvF94b04uCeqSTFe6OdPWNMFxDu3EcWFPYRxZV+Xpq/kZlLtjF//U5qT0uP1AQG9kjmh8cO4KzhffB4JLoZNcbslywo7Md2lFbxyZoCNhSUsXFnBQs37GLV9lKG5aTzm9MOoW+3JIor/JRVBxjVrxsZSb5oZ9kYs48LNyjYiOZ9UI/UBM4Z2bfufTCovPHVJv42YyVXPjV/t7RJPi/nj87hyuMGcnDP1M7OqjGmi7GSwn6k0h/gvWXbUIX0JB9eEV5ftIlpizZTHQgS5xGCqigwtG86543K4ZyRfemZnhjtrBtjosyqj2LIjtIqXv9yE7vKqxGEgCofr97B13lFeAQOzE6ld3oivdITGZCVzKF90hnSJ42cbkmIWBuFMbFgn6g+EpFxwMOAF/iXqt7bTLrzgZeBI1XVrvht1CM1gatPPHCP5au3lzLtq82s3FrC1uJKVq/ewSsLK+vWez1CcryX1IQ4eqYlcHj/TI44IJOBWSmUVPoprPDjDwTpmZZITrckeqYnkBDnsUBiTBcWsZKCiHiBlcCpQB4wH7hUVZc2SpcGvAXEAz9vLShYSWHvlFbVsGJrMUu3lLC1qIKyqgDl1TVs2FnOVxuLqPAHWvy8CCTEeUiOj6N3eiI5mUn0y0zm0D5pDO2bzqCeaTZNuDH7oH2hpHAUsFpV14Yy9CJwLtD4yfZ3A/cBN0UwLyYkNSGO0Qd0Z/QB3fdYVxMIsnxrCZsLK0hP8tEt2UecR9haVMXmogryS6qo8geoqglSUlXDlsIK1heU8dGqHXXBpLb0kejzEu/1oKpUB5SaYJBgUFGFoCoZST56ZSTSJyORPhlJ9O2WRE63RHqmJ5KVEk/3lHhKKmtYvKmIJZuL8XqEs0b04cBsa0w3JpIiGRRygI0N3ucBRzdMICJHAP1U9S0RaTYoiMgEYAJA//79I5BVAxDn9TAsJ4NhORm7LT+4Z1qLnwsGlXUFZSzeXMzKrSWUVtVQVROkqiaAV4Q4rwefV/CI+wdQWFHNtuJKVmwtYdby/BZLKB4BBR54dyUjcjM4akB3yqprKCz3A65RfURut7reV4Gg4g8EqQ4E8dcoVTUBSqpqKK2socIfoE9GIgOyUujbLQlvG8Z91JaqrfrMdGVR65IqIh7gAeDK1tKq6mRgMrjqo8jmzLSVxyMcmJ3q7uJHtv3zqkphuZ9Nha40UlBWzc6yKpJ8Xg7rm8GQPmkUV9Twv6828/qiTTz76XoyknxkJPnwB4JMX7y1XfmO93rITkugR1oC2anxddVeqlBeHaCowk9xhZ/SqhrKqmoo9wfISPIxqGcqB/dMo2daAj6vC3rpiT5yM5PIzUwiKzUBr0fwiuDxgM/jqRt0WBMIUuEP4A8oiT4PiXHeZgckBoKKRywImc4VyaCwCejX4H1uaFmtNGAYMDv0o+8NTBORc6yxObaICJkp8S0+mS45Po5rvnMg13xnzwb1ogo/izcVsa6gDK8IXo/g83qIj/Pg83pIiPOQmhhHWkIcCXFeNhVWsK6gjHUFZeQXV5FfWsWmwkpqQpMSKpAS7yU9yUdOZhLpiXEkx8eRHO+loKya1dtKmb54S11JJRxejyBATXDPe5qEOJfXhDgPXo9Q6Q9SXl2DP6CuOs7nJTHeW5cu3ush0eclyecl0echKd5Lki+OpHgPu8r9bCgoZ8POcuLjPBzaO41De6eRkhDH1qJKthRV4vN6OObA7hx3UA9yMpNYvb2UldtK3DqPEB/nttkrPZG+GUl0S/axvaSKLaEqRH8gSO38jf26JzGoZxoDeiTjFaGyJkilP0BqQhyJvr2bosVVPQYprwpQVl0DQM+0RGuzirBINjTH4RqaT8EFg/nAZaq6pJn0s4HfWEOz2V8Eg4o/GCQQVHaV+8nbWU7ergp2lVcTVCWo9VVZNQElqEqSz0tSvJc4j7uAVlQHqAy109SmS/R5SE6IIzHOS3UgQHl1gIrqANU1QaoCQar8rmqu0h+gwh+g0u+2U+EPkJ4YR/+sFPplJlHpD7J8azGrtpdSXROkR2oCfTISKan0s64TnueR6POQmRyPKlT46/OX0y2JnMwkAkFla3EVW4sqqKgOEB/nAl9Q1ZXMqgNNBtGslHiy0xLqAqMvzoM/VF0ZCCrJ8XGkJMSRFO+lrKqmrrSXkeSjd0Yi2akJ7CyrJm9XBZsKK8hKjWdQzzQG90rFHwjWLU9NiGNwrzQO6Z2G1yN1wXZnWTWV/gCVNQES4rwckJXMgKwUemckEu/1EOd1pcSAKjVBrWtLA3dTUBrKU4U/QFZKPL3SE+mZnkCfjCQyk32ICCWVfr7aWMQ3m4pITYxjQGgffTISifO2LyhGvaFZVWtE5OfADFyX1CmqukRE7gIWqOq0SO3bmM7g8QgJHnc3nBzvLnZHt/KZaKgJBAkqu91hbymq4JPVBeSXVjGoZyqDe7lxK8HQ3XlZVSBUsqigsNxPdloCfbol1t2p11701heUsXp7Ket2lCPiRtgn+DyUVrk2n11l1XhESIp3y4sr/OTtqmD5lhI8HqFPRiKDe2aTHO+lOuACqAApCa5klhzvJSUhjpT4OIKqbCuuYmtxJTtKq9yF2R+gvCJAgtf1iPN6hIrqAJsKK6ioriElIY6MJB/9UpIpLK9m4YZd5JdUkZkcT7/MZI4ckMmO0mrmrsrnlYV5APRIjadvtyTydlXwzpKtNLxvTkuMcwEpzpXSCkqr+XRtAeXVLffaC1dCnIeslHi2FFfS1P36T44fwO1nD+2QfTXHBq8ZYwxQVO6vqzqrVVEdYPX2UhTlgO4pZCTvOc+YqpJfWsX24ipqQiXDQFCJ8wieUNuSCAjuNT3RR1qiq17bWe46XGwLVe1tLa4kv6SKAVkpHHFAN0bkdKPCH2BdQRnrC8o4uGcaow/IbNfx2YhmY4wxdcINCtZiY4wxpo4FBWOMMXUsKBhjjKljQcEYY0wdCwrGGGPqWFAwxhhTx4KCMcaYOhYUjDHG1NnvBq+JSD6wvp0f7wHs6MDs7C9i8bhj8ZghNo87Fo8Z2n7cB6hqdmuJ9rugsDdEZEE4I/q6mlg87lg8ZojN447FY4bIHbdVHxljjKljQcEYY0ydWAsKk6OdgSiJxeOOxWOG2DzuWDxmiNBxx1SbgjHGmJbFWknBGGNMCywoGGOMqRMzQUFExonIChFZLSK3RDs/kSAi/URklogsFZElInJDaHl3EXlXRFaFXtv36KZ9nIh4ReRLEXkz9H6giHwWOuf/EZH4aOexI4lINxF5WUSWi8gyETk2Fs61iPxf6Pe9WESmikhiVzzXIjJFRLaLyOIGy5o8v+I8Ejr+r0XkiPbuNyaCgoh4gYnAGcBhwKUiclh0cxURNcCvVfUw4Bjg+tBx3gK8r6qDgPdD77uiG4BlDd7fBzyoqgcDu4CropKryHkYeEdVDwVG4o69S59rEckBfgmMUdVhuOe/X0LXPNdPA+MaLWvu/J4BDAr9mwA81t6dxkRQAI4CVqvqWlWtBl4Ezo1ynjqcqm5R1YWhv0twF4kc3LE+E0r2DHBedHIYOSKSC5wJ/Cv0XoCTgZdDSbrUcYtIBvAd4EkAVa1W1UJi4FwDcUCSiMQBycAWuuC5VtW5wM5Gi5s7v+cCz6rzKdBNRPq0Z7+xEhRygI0N3ueFlnVZIjIAOBz4DOilqltCq7YCvaKUrUh6CPgtEAy9zwIKVbUm9L6rnfOBQD7wVKjK7F8ikkIXP9equgn4G7ABFwyKgC/o2ue6oebOb4dd42IlKMQUEUkFXgFuVNXihuvU9UHuUv2QReQsYLuqfhHtvHSiOOAI4DFVPRwoo1FVURc915m4u+KBQF8ghT2rWGJCpM5vrASFTUC/Bu9zQ8u6HBHx4QLC86r6amjxttqiZOh1e7TyFyHHA+eIyDpc1eDJuPr2bqEqBuh65zwPyFPVz0LvX8YFia5+rr8HfKuq+arqB17Fnf+ufK4bau78dtg1LlaCwnxgUKiHQjyuYWpalPPU4UL16E8Cy1T1gQarpgE/Dv39Y+CNzs5bJKnqraqaq6oDcOf2A1W9HJgFXBBK1qWOW1W3AhtF5JDQolOApXTxc42rNjpGRJJDv/fa4+6y57qR5s7vNOBHoV5IxwBFDaqZ2iRmRjSLyHhcvbMXmKKq90Q5Sx1ORE4APgS+ob5u/Xe4doWXgP64accvUtXGDVhdgoiMBX6jqmeJyIG4kkN34EvgClWtimb+OpKIjMI1rMcDa4Gf4G70uvS5FpE7gYtxve2+BK7G1Z93qXMtIlOBsbgpsrcBtwOv08T5DQXIf+Kq0sqBn6jqgnbtN1aCgjHGmNbFSvWRMcaYMFhQMMYYU8eCgjHGmDoWFIwxxtSxoGCMMaaOBQVjOpGIjK2dxdWYfZEFBWOMMXUsKBjTBBG5QkQ+F5FFIvJ46FkNpSLyYGgu//dFJDuUdpSIfBqax/61BnPcHywi74nIVyKyUEQOCm0+tcFzEJ4PDTwyZp9gQcGYRkRkCG7E7PGqOgoIAJfjJl9boKpDgTm4EaYAzwI3q+oI3Gjy2uXPAxNVdSRwHG5WT3Cz196Ie7bHgbi5e4zZJ8S1nsSYmHMKMBqYH7qJT8JNPBYE/hNK8xzwaui5Bt1UdU5o+TPAf0UkDchR1dcAVLUSILS9z1U1L/R+ETAA+Cjyh2VM6ywoGLMnAZ5R1Vt3WyhyW6N07Z0jpuGcPAHs/6HZh1j1kTF7eh+4QER6Qt1zcQ/A/X+pnYnzMuAjVS0CdonIiaHlPwTmhJ58lyci54W2kSAiyZ16FMa0g92hGNOIqi4VkT8AM0XEA/iB63EPsjkqtG47rt0B3BTGk0IX/drZSsEFiMdF5K7QNi7sxMMwpl1sllRjwiQipaqaGu18GBNJVn1kjDGmjpUUjDHG1LGSgjHGmDoWFIwxxtSxoGCMMaaOBQVjjDF1LCgYY4yp8/8BI4VFHAnikZoAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot(trained_model.history['loss'])\n",
+    "plt.plot(trained_model.history['val_loss'])\n",
+    "plt.title('model loss')\n",
+    "plt.ylabel('loss')\n",
+    "plt.xlabel('epoch')\n",
+    "plt.legend(['train', 'test'], loc='upper left')\n",
+    "\n",
+    "print(np.min(trained_model.history['loss']))\n",
+    "print(np.min(trained_model.history['val_loss']))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernel_info": {
+   "name": "python3"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "nteract": {
+   "version": "0.14.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/docs/larq/tutorials/mnist.ipynb
+++ b/docs/larq/tutorials/mnist.ipynb
@@ -9,9 +9,18 @@
    "source": [
     "# Introduction to BNNs with Larq\n",
     "\n",
-    "<a href=\"https://mybinder.org/v2/gh/larq/docs/master?filepath=docs%2Flarq%2Ftutorials%2Fmnist.ipynb\"><button class=\"notebook-badge\">Run on Binder</button></a> <a href=\"https://github.com/larq/docs/blob/master/docs/larq/tutorials/mnist.ipynb\"><button class=\"notebook-badge\">View on GitHub</button></a>\n",
+    "<a href=\"https://colab.research.google.com/github/larq/docs/blob/master/docs/larq/tutorials/mnist.ipynb\"><button class=\"notebook-badge\">Run on Colab</button></a> <a href=\"https://github.com/larq/docs/blob/master/docs/larq/tutorials/mnist.ipynb\"><button class=\"notebook-badge\">View on GitHub</button></a>\n",
     "\n",
     "This tutorial demonstrates how to train a simple binarized Convolutional Neural Network (CNN) to classify MNIST digits. This simple network will achieve approximately 98% accuracy on the MNIST test set. This tutorial uses Larq and the [Keras Sequential API](https://www.tensorflow.org/guide/keras), so creating and training our model will require only a few lines of code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install larq"
    ]
   },
   {
@@ -46,16 +55,7 @@
     "colab_type": "code",
     "id": "JWoEqyMuXFF4"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Downloading data from https://storage.googleapis.com/tensorflow/tf-keras-datasets/mnist.npz\n",
-      "11493376/11490434 [==============================] - 1s 0us/step\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "(train_images, train_labels), (test_images, test_labels) = tf.keras.datasets.mnist.load_data()\n",
     "\n",
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 10,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -229,20 +229,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Train on 60000 samples\n",
       "Epoch 1/6\n",
-      "60000/60000 [==============================] - 16s 270us/sample - loss: 0.6429 - accuracy: 0.9095\n",
+      "938/938 [==============================] - 20s 21ms/step - loss: 0.4231 - accuracy: 0.9771\n",
       "Epoch 2/6\n",
-      "60000/60000 [==============================] - 15s 255us/sample - loss: 0.4732 - accuracy: 0.9622\n",
+      "938/938 [==============================] - 20s 21ms/step - loss: 0.4186 - accuracy: 0.9788\n",
       "Epoch 3/6\n",
-      "60000/60000 [==============================] - 15s 251us/sample - loss: 0.4483 - accuracy: 0.9691\n",
+      "938/938 [==============================] - 21s 22ms/step - loss: 0.4170 - accuracy: 0.9787\n",
       "Epoch 4/6\n",
-      "60000/60000 [==============================] - 15s 256us/sample - loss: 0.4356 - accuracy: 0.9737\n",
+      "938/938 [==============================] - 21s 23ms/step - loss: 0.4126 - accuracy: 0.9793\n",
       "Epoch 5/6\n",
-      "60000/60000 [==============================] - 15s 253us/sample - loss: 0.4304 - accuracy: 0.9754\n",
+      "938/938 [==============================] - 21s 23ms/step - loss: 0.4142 - accuracy: 0.9803\n",
       "Epoch 6/6\n",
-      "60000/60000 [==============================] - 15s 257us/sample - loss: 0.4276 - accuracy: 0.9767\n",
-      "10000/10000 [==============================] - 1s 135us/sample - loss: 0.3899 - accuracy: 0.9800\n"
+      "938/938 [==============================] - 21s 22ms/step - loss: 0.4124 - accuracy: 0.9814\n",
+      "313/313 [==============================] - 2s 5ms/step - loss: 0.4507 - accuracy: 0.9762\n"
      ]
     }
    ],
@@ -268,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -279,7 +278,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Test accuracy 98.00 %\n"
+      "Test accuracy 97.62 %\n"
      ]
     }
    ],
@@ -294,7 +293,7 @@
     "id": "8cfJ8AR03gT5"
    },
    "source": [
-    "As you can see, our simple binarized CNN has achieved a test accuracy of 98 %. Not bad for a few lines of code!\n",
+    "As you can see, our simple binarized CNN has achieved a test accuracy of around 98 %. Not bad for a few lines of code!\n",
     "\n",
     "For information on converting Larq models to an optimized format and using or benchmarking them on Android or ARM devices, have a look at [this guide](https://docs.larq.dev/compute-engine/end_to_end/)."
    ]
@@ -328,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.5"
   },
   "nteract": {
    "version": "0.14.3"

--- a/docs/zoo/tutorials.ipynb
+++ b/docs/zoo/tutorials.ipynb
@@ -1,263 +1,301 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "source": [
-        "# Larq Zoo Tutorial\n",
-        "\n",
-        "<a href=\"https://mybinder.org/v2/gh/larq/docs/master?filepath=docs%2Fzoo%2Ftutorials.ipynb\"><button class=\"notebook-badge\">Run on Binder</button></a> <a href=\"https://github.com/larq/docs/blob/master/docs/zoo/tutorials.ipynb\"><button class=\"notebook-badge\">View on GitHub</button></a>\n",
-        "\n",
-        "This tutorial demonstrates how to load pretrained models from Larq Zoo. These models can be used for prediction, feature extraction, and fine-tuning."
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "import tensorflow as tf\n",
-        "import tensorflow_datasets as tfds\n",
-        "import numpy as np\n",
-        "import larq_zoo as lqz\n",
-        "from urllib.request import urlopen"
-      ],
-      "outputs": [],
-      "execution_count": 1,
-      "metadata": {
-        "collapsed": false,
-        "outputHidden": false,
-        "inputHidden": false
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Download and prepare a sample image\n",
-        "\n",
-        "In the following we will use a sample image from the [ImageNet](http://image-net.org/) dataset:\n",
-        "<img src=\"https://raw.githubusercontent.com/larq/zoo/master/tests/fixtures/elephant.jpg\" width=\"50%\">"
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "img_path = \"https://raw.githubusercontent.com/larq/zoo/master/tests/fixtures/elephant.jpg\"\n",
-        "\n",
-        "with urlopen(img_path) as f:\n",
-        "    img = tf.keras.preprocessing.image.load_img(f, target_size=(224, 224))\n",
-        "\n",
-        "x = tf.keras.preprocessing.image.img_to_array(img)\n",
-        "x = lqz.preprocess_input(x)\n",
-        "x = np.expand_dims(x, axis=0)"
-      ],
-      "outputs": [],
-      "execution_count": 2,
-      "metadata": {
-        "collapsed": false,
-        "outputHidden": false,
-        "inputHidden": false
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Classify ImageNet classes with Bi-Real Net\n",
-        "\n",
-        "We will first load the Bi-Real Net architecture with pretrained weights and predict the image class."
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "model = lqz.literature.BiRealNet(weights=\"imagenet\")\n",
-        "preds = model.predict(x)\n",
-        "lqz.decode_predictions(preds, top=5)[0]"
-      ],
-      "outputs": [
-        {
-          "output_type": "execute_result",
-          "execution_count": 4,
-          "data": {
-            "text/plain": [
-              "[('n02504458', 'African_elephant', 0.7529364),\n",
-              " ('n01871265', 'tusker', 0.22607337),\n",
-              " ('n02504013', 'Indian_elephant', 0.017037684),\n",
-              " ('n02410509', 'bison', 0.0016636014),\n",
-              " ('n02412080', 'ram', 0.0014974006)]"
-            ]
-          },
-          "metadata": {}
-        }
-      ],
-      "execution_count": 4,
-      "metadata": {
-        "collapsed": false,
-        "outputHidden": false,
-        "inputHidden": false
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Extract features with Bi-Real Net\n",
-        "\n",
-        "Larq Zoo models can also be used to extract features that can be used as input to a second model."
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "tf.keras.backend.clear_session()\n",
-        "model = lqz.literature.BiRealNet(weights=\"imagenet\", include_top=False)\n",
-        "features = model.predict(x)\n",
-        "print(\"Feature shape:\", features.shape)"
-      ],
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "Feature shape: (1, 7, 7, 512)\n"
-          ]
-        }
-      ],
-      "execution_count": 5,
-      "metadata": {
-        "collapsed": false,
-        "outputHidden": false,
-        "inputHidden": false
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Extract features from an arbitrary intermediate layer\n",
-        "\n",
-        "Features can also be extracted from arbitrary intermediate layer with just a few lines of code."
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "avg_pool_layer = model.get_layer(\"average_pooling2d_2\")\n",
-        "avg_pool_model = tf.keras.models.Model(\n",
-        "    inputs=model.input, outputs=avg_pool_layer.output)\n",
-        "\n",
-        "avg_pool_features = avg_pool_model.predict(x)\n",
-        "print(\"average_pooling2d_2 feature shape:\", avg_pool_features.shape)"
-      ],
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": [
-            "average_pooling2d_2 feature shape: (1, 7, 7, 256)\n"
-          ]
-        }
-      ],
-      "execution_count": 6,
-      "metadata": {
-        "collapsed": false,
-        "outputHidden": false,
-        "inputHidden": false
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Build Bi-Real Net over a custom input Tensor\n",
-        "\n",
-        "The model can also be used with an input Tensor that might also be the output a different Keras model or layer."
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "input_tensor = tf.keras.layers.Input(shape=(224, 224, 3))\n",
-        "\n",
-        "model = lqz.literature.BiRealNet(input_tensor=input_tensor, weights=\"imagenet\")"
-      ],
-      "outputs": [],
-      "execution_count": 7,
-      "metadata": {
-        "collapsed": false,
-        "outputHidden": false,
-        "inputHidden": false
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "### Evaluate Bi-Real Net with TensorFlow Datasets\n",
-        "\n",
-        "To re-run the evaluation on the entire [ImageNet](http://image-net.org/) validation dataset [Tensorflow Datasets](https://www.tensorflow.org/datasets/) can be used.\n",
-        "\n",
-        "Note that running this example will require [**mannualy downloading**](https://www.tensorflow.org/datasets/catalog/imagenet2012) the entire dataset and might take a very long time to complete."
-      ],
-      "metadata": {}
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "def preprocess(data):\n",
-        "    img = lqz.preprocess_input(data[\"image\"])\n",
-        "    label = tf.one_hot(data[\"label\"], 1000)\n",
-        "    return img, label \n",
-        "\n",
-        "dataset = (\n",
-        "    tfds.load(\"imagenet2012:5.0.0\", split=tfds.Split.VALIDATION)\n",
-        "    .map(preprocess, num_parallel_calls=tf.data.experimental.AUTOTUNE)\n",
-        "    .batch(128)\n",
-        "    .prefetch(1)\n",
-        ")\n",
-        "\n",
-        "model = lqz.literature.BiRealNet()\n",
-        "model.compile(\n",
-        "    optimizer=\"sgd\",\n",
-        "    loss=\"categorical_crossentropy\",\n",
-        "    metrics=[\"categorical_accuracy\", \"top_k_categorical_accuracy\"],\n",
-        ")\n",
-        "\n",
-        "model.evaluate(dataset)"
-      ],
-      "outputs": [],
-      "execution_count": 8,
-      "metadata": {
-        "collapsed": false,
-        "outputHidden": false,
-        "inputHidden": false
-      }
-    }
-  ],
-  "metadata": {
-    "kernel_info": {
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.7.4",
-      "mimetype": "text/x-python",
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "pygments_lexer": "ipython3",
-      "nbconvert_exporter": "python",
-      "file_extension": ".py"
-    },
-    "kernelspec": {
-      "name": "python3",
-      "language": "python",
-      "display_name": "Python 3"
-    },
-    "nteract": {
-      "version": "0.15.0"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Larq Zoo Tutorial\n",
+    "\n",
+    "<a href=\"https://colab.research.google.com/github/larq/docs/blob/master/docs/zoo/tutorials.ipynb\"><button class=\"notebook-badge\">Run on Colab</button></a> <a href=\"https://github.com/larq/docs/blob/master/docs/zoo/tutorials.ipynb\"><button class=\"notebook-badge\">View on GitHub</button></a>\n",
+    "\n",
+    "This tutorial demonstrates how to load pretrained models from Larq Zoo. These models can be used for prediction, feature extraction, and fine-tuning."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install larq larq-zoo "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "inputHidden": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "import tensorflow_datasets as tfds\n",
+    "import numpy as np\n",
+    "import larq_zoo as lqz\n",
+    "from urllib.request import urlopen\n",
+    "from PIL import Image"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Download and prepare a sample image\n",
+    "\n",
+    "In the following we will use a sample image from the [ImageNet](http://image-net.org/) dataset:\n",
+    "<img src=\"https://raw.githubusercontent.com/larq/zoo/master/tests/fixtures/elephant.jpg\" width=\"50%\">"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "inputHidden": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "img_path = \"https://raw.githubusercontent.com/larq/zoo/master/tests/fixtures/elephant.jpg\"\n",
+    "\n",
+    "with urlopen(img_path) as f:\n",
+    "    img = Image.open(f).resize((224, 224))\n",
+    "\n",
+    "x = tf.keras.preprocessing.image.img_to_array(img)\n",
+    "x = lqz.preprocess_input(x)\n",
+    "x = np.expand_dims(x, axis=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Classify ImageNet classes with QuickNet\n",
+    "\n",
+    "We will first load the QuickNet architecture with pretrained weights and predict the image class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false,
+    "inputHidden": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "outputHidden": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('n02504458', 'African_elephant', 0.57994586),\n",
+       " ('n01871265', 'tusker', 0.41163084),\n",
+       " ('n02504013', 'Indian_elephant', 0.008422509),\n",
+       " ('n02410509', 'bison', 1.6847167e-07),\n",
+       " ('n02412080', 'ram', 1.3900193e-07)]"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model = lqz.sota.QuickNet(weights=\"imagenet\")\n",
+    "preds = model.predict(x)\n",
+    "lqz.decode_predictions(preds, top=5)[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extract features with QuickNet\n",
+    "\n",
+    "Larq Zoo models can also be used to extract features that can be used as input to a second model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false,
+    "inputHidden": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "outputHidden": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Feature shape: (1, 7, 7, 512)\n"
+     ]
+    }
+   ],
+   "source": [
+    "tf.keras.backend.clear_session()\n",
+    "model = lqz.sota.QuickNet(weights=\"imagenet\", include_top=False)\n",
+    "features = model.predict(x)\n",
+    "print(\"Feature shape:\", features.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extract features from an arbitrary intermediate layer\n",
+    "\n",
+    "Features can also be extracted from arbitrary intermediate layer with just a few lines of code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false,
+    "inputHidden": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "outputHidden": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "add_7 feature shape: (1, 14, 14, 256)\n"
+     ]
+    }
+   ],
+   "source": [
+    "avg_pool_layer = model.get_layer(\"add_7\")\n",
+    "avg_pool_model = tf.keras.models.Model(\n",
+    "    inputs=model.input, outputs=avg_pool_layer.output)\n",
+    "\n",
+    "avg_pool_features = avg_pool_model.predict(x)\n",
+    "print(\"add_7 feature shape:\", avg_pool_features.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Build QuickNet over a custom input Tensor\n",
+    "\n",
+    "The model can also be used with an input Tensor that might also be the output a different Keras model or layer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false,
+    "inputHidden": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "input_tensor = tf.keras.layers.Input(shape=(224, 224, 3))\n",
+    "\n",
+    "model = lqz.sota.QuickNet(input_tensor=input_tensor, weights=\"imagenet\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evaluate QuickNet with TensorFlow Datasets\n",
+    "\n",
+    "To re-run the evaluation on the entire [ImageNet](http://image-net.org/) validation dataset [Tensorflow Datasets](https://www.tensorflow.org/datasets/) can be used.\n",
+    "\n",
+    "Note that running this example will require [**mannualy downloading**](https://www.tensorflow.org/datasets/catalog/imagenet2012) the entire dataset and might take a very long time to complete."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "inputHidden": false,
+    "jupyter": {
+     "outputs_hidden": false
+    },
+    "outputHidden": false
+   },
+   "outputs": [],
+   "source": [
+    "def preprocess(data):\n",
+    "    img = lqz.preprocess_input(data[\"image\"])\n",
+    "    label = tf.one_hot(data[\"label\"], 1000)\n",
+    "    return img, label \n",
+    "\n",
+    "dataset = (\n",
+    "    tfds.load(\"imagenet2012:5.0.0\", split=tfds.Split.VALIDATION)\n",
+    "    .map(preprocess, num_parallel_calls=tf.data.experimental.AUTOTUNE)\n",
+    "    .batch(128)\n",
+    "    .prefetch(1)\n",
+    ")\n",
+    "\n",
+    "model = lqz.sota.QuickNet()\n",
+    "model.compile(\n",
+    "    optimizer=\"sgd\",\n",
+    "    loss=\"categorical_crossentropy\",\n",
+    "    metrics=[\"categorical_accuracy\", \"top_k_categorical_accuracy\"],\n",
+    ")\n",
+    "\n",
+    "model.evaluate(dataset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernel_info": {
+   "name": "python3"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "nteract": {
+   "version": "0.15.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
 tensorflow-cpu==2.3.0
-tensorflow_datasets==3.2.1
 tensorflow_metadata==0.22.2  # Pinned due to https://github.com/tensorflow/metadata/pull/10
-Pillow==7.2.0
-matplotlib==3.3.1
 mkdocs==1.1.2
 mkdocs-material==5.5.10
 pymdown-extensions==8.0


### PR DESCRIPTION
We currently allow users to run notebooks on Binder. Binder is great, but unfortunately the Docker build takes quite some time since it needs to install TensorFlow which is discouraging for users.

This PR switches to https://colab.research.google.com/ which has support for GPUs and is commonly used in the TensorFlow ecosystem. I also fixed a few bugs in the larq zoo tutorial which were introduced in a recent keras preprocessing update.

Closes #14