### PR TITLE
Implement dark mode with automatic switching, and new green accent color

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -17,6 +17,7 @@
 [data-md-color-scheme=slate] {
   --md-default-fg-color--lightest: hsla(0, 0%, 100%, 0.7);
   --md-typeset-a-color: var(--larq-green-darker);
+  --md-default-fg-color--light: hsla(0, 0%, 100%, 0.9);
 }
 
 .md-footer {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -6,17 +6,18 @@
   --md-default-fg-color: #0a1d3c;
   --md-default-fg-color--light: #0a1d3c99;
   --md-default-fg-color--lightest: #0a1d3c14;
-  --md-accent-fg-color: var(--larq-green);
+  --md-accent-fg-color: var(--larq-green-darker);
 }
 
 [data-md-color-primary=white] {
-  --md-primary-fg-color: var(--larq-green-darker);
   --md-typeset-a-color: var(--larq-green-darkest);
 }
 
 [data-md-color-scheme=slate] {
+  --md-primary-fg-color: var(--larq-green-darker);
   --md-default-fg-color--lightest: hsla(0, 0%, 100%, 0.7);
   --md-typeset-a-color: var(--larq-green-darker);
+  --md-accent-fg-color: var(--larq-green-darkest);
   --md-default-fg-color--light: hsla(0, 0%, 100%, 0.9);
 }
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,7 +1,20 @@
 :root {
+  --larq-green: #7DFB9A;
+  --larq-green-darker: #5FBF75;
+  --larq-blue: #0A1D3C;
   --md-default-fg-color: #0a1d3c;
   --md-default-fg-color--light: #0a1d3c99;
   --md-default-fg-color--lightest: #0a1d3c14;
+  --md-accent-fg-color: var(--larq-green);
+}
+
+[data-md-color-primary=white] {
+  --md-primary-fg-color: var(--larq-green-darker);
+  --md-typeset-a-color: var(--larq-green-darker);
+}
+
+[data-md-color-scheme=slate] {
+  --md-default-fg-color--lightest: hsla(0, 0%, 100%, 0.7);
 }
 
 .md-footer {
@@ -13,8 +26,7 @@ h3 {
   padding-top: 8px !important;
 }
 
-.md-nav__title .md-nav__button.md-logo img,
-.md-header-nav__button.md-logo img {
+.md-nav__title .md-nav__button.md-logo img, .md-header-nav__button.md-logo img {
   width: unset;
 }
 
@@ -33,6 +45,10 @@ h3 {
   color: inherit;
 }
 
+.md-typeset .tabbed-set>input:checked+label {
+  color: var(--larq-green-darker);
+}
+
 .model-summary {
   overflow: scroll;
   max-height: 20rem;
@@ -40,6 +56,7 @@ h3 {
 
 .notebook-badge {
   border: 0.05rem solid var(--md-default-fg-color--lightest);
+  color: var(--md-typeset-color);
   padding: 0.45em 1.05em;
   border-radius: 2px;
   cursor: pointer;

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -11,6 +11,7 @@
 
 [data-md-color-primary=white] {
   --md-typeset-a-color: var(--larq-green-darkest);
+  --md-footer-bg-color: #0a1d3c;
 }
 
 [data-md-color-scheme=slate] {
@@ -19,10 +20,7 @@
   --md-typeset-a-color: var(--larq-green-darker);
   --md-accent-fg-color: var(--larq-green-darkest);
   --md-default-fg-color--light: hsla(0, 0%, 100%, 0.9);
-}
-
-.md-footer {
-  --md-footer-bg-color: #0a1d3c;
+  --md-footer-bg-color: rgb(36, 38, 53);
 }
 
 h3 {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,6 +1,7 @@
 :root {
   --larq-green: #7DFB9A;
   --larq-green-darker: #5FBF75;
+  --larq-green-darkest: hsl(131.9, 76.6%, 28.4%);
   --larq-blue: #0A1D3C;
   --md-default-fg-color: #0a1d3c;
   --md-default-fg-color--light: #0a1d3c99;
@@ -10,11 +11,12 @@
 
 [data-md-color-primary=white] {
   --md-primary-fg-color: var(--larq-green-darker);
-  --md-typeset-a-color: var(--larq-green-darker);
+  --md-typeset-a-color: var(--larq-green-darkest);
 }
 
 [data-md-color-scheme=slate] {
   --md-default-fg-color--lightest: hsla(0, 0%, 100%, 0.7);
+  --md-typeset-a-color: var(--larq-green-darker);
 }
 
 .md-footer {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ theme:
     repo: fontawesome/brands/github
   palette:
     primary: white
+    scheme: preference
     # accent: blue
   font:
     text: "Work Sans"


### PR DESCRIPTION
This PR implements automatic dark mode, which follows the user's OS-level preference - if your OS is in light mode, the UI will be light and if it's dark it'll be dark. (This only goes into effect after refreshing the page.)

I've also added a new `--larq-green-darker` color, which has the same hue and saturation as `--larq-green` (the logo color) but has brightness 75 instead of 98. This makes it usable for links, which is what I've used it for (links are `--larq-green` on hover.)

The biggest place where you'll see `--larq-green-darker` is in the top navigation bar. I personally think this looks nice, and it can also stay the same between dark and light mode - making the top bar dark/light depending on the mode is a bit trickier since it doesn't stand out properly in dark mode and looked a bit weird when I tried it.

---

Light mode (updated 3d85657):
![Screen Shot 2020-09-08 at 15 07 22](https://user-images.githubusercontent.com/7980521/92480333-0a401c80-f1e5-11ea-8ae3-d2238a8db298.png)

Dark mode (updated 3d85657):
![Screen Shot 2020-09-08 at 15 07 30](https://user-images.githubusercontent.com/7980521/92480347-0f04d080-f1e5-11ea-816f-9a08acd61600.png)
