### PR TITLE
Add MeliusNet22 to generation script

### DIFF
--- a/generate_docs.py
+++ b/generate_docs.py
@@ -48,6 +48,7 @@ repo_apis = {
             "larq_zoo.literature.BinaryDenseNet37Dilated",
             "larq_zoo.literature.BinaryDenseNet45",
             "larq_zoo.literature.DoReFaNet",
+            "larq_zoo.literature.MeliusNet22",
             "larq_zoo.literature.RealToBinaryNet",
             "larq_zoo.literature.XNORNet",
         ],


### PR DESCRIPTION
This way it'll show up on /zoo/api/literature, where it's currently missing.