### PR TITLE
Fix netron links

### DIFF
--- a/docs/compute-engine/end_to_end.ipynb
+++ b/docs/compute-engine/end_to_end.ipynb
@@ -341,7 +341,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that the model is converted, it is useful to visualize it in [Netron](https://lutzroeder.github.io/netron/) to make sure the network looks as expected. Simply go to [Netron](https://lutzroeder.github.io/netron/) and select the `.tflite` file to visualize it (press Ctrl + K to switch to horizontal mode). For the model above, the first part of the flatbuffer looks like this:\n",
+    "Now that the model is converted, it is useful to visualize it in [Netron](https://netron.app/) to make sure the network looks as expected. Simply go to [Netron](https://netron.app/) and select the `.tflite` file to visualize it (press Ctrl + K to switch to horizontal mode). For the model above, the first part of the flatbuffer looks like this:\n",
     "\n",
     "![](../images/custom_model_netron_1.png)\n",
     "\n",

--- a/netron_link.py
+++ b/netron_link.py
@@ -1,4 +1,4 @@
-netron_link = "https://lutzroeder.github.io/netron"
+netron_link = "https://netron.app"
 cors_proxy = "https://cors-anywhere.herokuapp.com"
 release_url = "https://github.com/larq/zoo/releases/download"
 


### PR DESCRIPTION
The URL of netron changed which breaks our interactive model visualizations. This PR updates any references to the old URL.