### PR TITLE
Fix netron URLs

### DIFF
--- a/netron_link.py
+++ b/netron_link.py
@@ -1,5 +1,5 @@
 netron_link = "https://netron.app"
-cors_proxy = "https://cors-anywhere.herokuapp.com"
+cors_proxy = "https://cors.bridged.cc"
 release_url = "https://github.com/larq/zoo/releases/download"
 
 


### PR DESCRIPTION
The CORS proxy we where using isn't available anymore. See https://github.com/Rob--W/cors-anywhere/issues/301#issuecomment-778800455

This PR switches to another service to fix our Netron links.