### PR TITLE
making the binary executable on device

### DIFF
--- a/docs/compute-engine/benchmark.md
+++ b/docs/compute-engine/benchmark.md
@@ -53,7 +53,7 @@ Larq Compute Engine provides prebuilt binaries to benchmark [Larq converted mode
        
     7. Make the binary executable:
        ```
-       adb shell +x /data/local/tmp/lce_benchmark_model
+       adb shell chmod +x /data/local/tmp/lce_benchmark_model
        ```
 
     8. Benchmark the model:

--- a/docs/compute-engine/benchmark.md
+++ b/docs/compute-engine/benchmark.md
@@ -45,7 +45,6 @@ Larq Compute Engine provides prebuilt binaries to benchmark [Larq converted mode
        ```
        adb push lce_benchmark_model /data/local/tmp
        ```
-    
     6. Transfer the converted `.tflite` model file to your phone:
        ```
        adb push quicknet.tflite /data/local/tmp

--- a/docs/compute-engine/benchmark.md
+++ b/docs/compute-engine/benchmark.md
@@ -45,6 +45,7 @@ Larq Compute Engine provides prebuilt binaries to benchmark [Larq converted mode
        ```
        adb push lce_benchmark_model /data/local/tmp
        ```
+
     6. Transfer the converted `.tflite` model file to your phone:
        ```
        adb push quicknet.tflite /data/local/tmp

--- a/docs/compute-engine/benchmark.md
+++ b/docs/compute-engine/benchmark.md
@@ -41,19 +41,19 @@ Larq Compute Engine provides prebuilt binaries to benchmark [Larq converted mode
        wget https://github.com/larq/compute-engine/releases/download/v0.6.0/lce_benchmark_model_android_arm64 -O lce_benchmark_model
        ```
 
-    5. Make the binary executable:
-       ```
-       chmod +x lce_benchmark_model
-       ```
-
-    6. Transfer the LCE inference binary to your phone:
+    5. Transfer the LCE inference binary to your phone:
        ```
        adb push lce_benchmark_model /data/local/tmp
        ```
-
-    7. Transfer the converted `.tflite` model file to your phone:
+    
+    6. Transfer the converted `.tflite` model file to your phone:
        ```
        adb push quicknet.tflite /data/local/tmp
+       ```
+       
+    7. Make the binary executable:
+       ```
+       adb shell +x /data/local/tmp/lce_benchmark_model
        ```
 
     8. Benchmark the model:


### PR DESCRIPTION
Earlier the lce_benchmark_model binary was made executable and then transferred to the device (Android phones) and this was failing on Windows. Now, the binary is made executable on the device and it runs as expected.