### PR TITLE
Update instructions for the Android example app

### DIFF
--- a/docs/compute-engine/android_example_with_lce.patch
+++ b/docs/compute-engine/android_example_with_lce.patch
@@ -1,0 +1,80 @@
+diff --git a/lite/examples/image_classification/android/build.gradle b/lite/examples/image_classification/android/build.gradle
+index 978712b5..5ad91d0b 100644
+--- a/lite/examples/image_classification/android/build.gradle
++++ b/lite/examples/image_classification/android/build.gradle
+@@ -18,6 +18,7 @@ allprojects {
+     repositories {
+         google()
+         mavenCentral()
++        mavenLocal()
+         maven {
+             name 'ossrh-snapshot'
+             url 'http://oss.sonatype.org/content/repositories/snapshots'
+diff --git a/lite/examples/image_classification/android/lib_support/build.gradle b/lite/examples/image_classification/android/lib_support/build.gradle
+index 518c000c..e055c8c3 100644
+--- a/lite/examples/image_classification/android/lib_support/build.gradle
++++ b/lite/examples/image_classification/android/lib_support/build.gradle
+@@ -39,11 +39,13 @@ dependencies {
+     implementation 'androidx.appcompat:appcompat:1.1.0'
+ 
+     // Build off of nightly TensorFlow Lite
+-    implementation 'org.tensorflow:tensorflow-lite:0.0.0-nightly-SNAPSHOT'
++    implementation 'org.larq:lce-lite:0.1.000'
++    // implementation 'org.tensorflow:tensorflow-lite:0.0.0-nightly-SNAPSHOT'
+     implementation 'org.tensorflow:tensorflow-lite-gpu:0.0.0-nightly-SNAPSHOT'
+ 
+-    implementation 'org.tensorflow:tensorflow-lite-support:0.1.0'
+-
++    implementation ('org.tensorflow:tensorflow-lite-support:0.1.0') {
++        exclude module: 'tensorflow-lite'
++    }
+     // Use local TensorFlow library
+     // implementation 'org.tensorflow:tensorflow-lite-local:0.0.0'
+ }
+diff --git a/lite/examples/image_classification/android/lib_support/src/main/java/org/tensorflow/lite/examples/classification/tflite/Classifier.java b/lite/examples/image_classification/android/lib_support/src/main/java/org/tensorflow/lite/examples/classification/tflite/Classifier.java
+index e7dbe25e..d46eaff4 100644
+--- a/lite/examples/image_classification/android/lib_support/src/main/java/org/tensorflow/lite/examples/classification/tflite/Classifier.java
++++ b/lite/examples/image_classification/android/lib_support/src/main/java/org/tensorflow/lite/examples/classification/tflite/Classifier.java
+@@ -219,7 +219,7 @@ public abstract class Classifier {
+         }
+         break;
+       case CPU:
+-        tfliteOptions.setUseXNNPACK(true);
++        tfliteOptions.setUseXNNPACK(false);
+         Log.d(TAG, "CPU execution");
+         break;
+     }
+diff --git a/lite/examples/image_classification/android/lib_support/src/main/java/org/tensorflow/lite/examples/classification/tflite/ClassifierFloatMobileNet.java b/lite/examples/image_classification/android/lib_support/src/main/java/org/tensorflow/lite/examples/classification/tflite/ClassifierFloatMobileNet.java
+index dd3b6aea..24b9d93c 100644
+--- a/lite/examples/image_classification/android/lib_support/src/main/java/org/tensorflow/lite/examples/classification/tflite/ClassifierFloatMobileNet.java
++++ b/lite/examples/image_classification/android/lib_support/src/main/java/org/tensorflow/lite/examples/classification/tflite/ClassifierFloatMobileNet.java
+@@ -25,9 +25,8 @@ import org.tensorflow.lite.support.common.ops.NormalizeOp;
+ public class ClassifierFloatMobileNet extends Classifier {
+ 
+   /** Float MobileNet requires additional normalization of the used input. */
+-  private static final float IMAGE_MEAN = 127.5f;
+-
+-  private static final float IMAGE_STD = 127.5f;
++  private static final float[] IMAGE_MEAN = {0.485f * 255, 0.456f * 255, 0.406f * 255};
++  private static final float[] IMAGE_STD = {0.229f * 255, 0.224f * 255, 0.225f * 255};
+ 
+   /**
+    * Float model does not need dequantization in the post-processing. Setting mean and std as 0.0f
+@@ -49,15 +48,12 @@ public class ClassifierFloatMobileNet extends Classifier {
+ 
+   @Override
+   protected String getModelPath() {
+-    // you can download this file from
+-    // see build.gradle for where to obtain this file. It should be auto
+-    // downloaded into assets.
+-    return "mobilenet_v1_1.0_224.tflite";
++    return "quicknet.tflite";
+   }
+ 
+   @Override
+   protected String getLabelPath() {
+-    return "labels.txt";
++    return "labels_without_background.txt";
+   }
+ 
+   @Override

--- a/docs/compute-engine/quickstart_android.md
+++ b/docs/compute-engine/quickstart_android.md
@@ -40,13 +40,13 @@ options: `supportDebug`, `debug`, `debug`, and `debug`. Then make sure you do a 
 
 ### 3. Add LCE-compatible TensorFlow Lite AAR to the project ###
 To add the LCE Lite AAR to your android project, you can either use the
-pre-built [LCE Lite AAR](https://github.com/larq/compute-engine/releases) (under 'assets')
+pre-built [LCE Lite AAR](https://github.com/larq/compute-engine/releases/latest) (under 'assets')
 or build the LCE Lite AAR yourself on your local machine. Both approaches are explained
 in detail in the following sections.
 
 === "Use the LCE Lite AAR from the GitHub release assets"
     To use LCE Lite AAR in the android app, we recommend downloading the
-    [LCE package released on GitHub under 'assets'](https://github.com/larq/compute-engine/releases) to your local machine. Then follow the instructions below as if you've built the AAR locally.
+    [LCE package released on GitHub under 'assets'](https://github.com/larq/compute-engine/releases/latest) to your local machine. Then follow the instructions below as if you've built the AAR locally.
 
     This AAR includes binaries for `arm64-v8a`, `x86_64`, `x86` [Android ABIs](https://developer.android.com/ndk/guides/abis).
     Please note that currently hand-optimized LCE operators are available only for `arm64-v8a`.

--- a/docs/compute-engine/quickstart_android.md
+++ b/docs/compute-engine/quickstart_android.md
@@ -3,10 +3,10 @@
 This guide describes how to build your own Android app using Larq Compute Engine (LCE) and
 [TensorFlow Lite Java Inference APIs](https://www.tensorflow.org/lite/guide/inference#load_and_run_a_model_in_java)
 to perform inference with a model built and trained with [Larq](https://larq.dev).
-This can be achieved either by using our pre-built [LCE Lite AAR hosted on Bintray](https://bintray.com/plumeraihq/larq-compute-engine), or you can build the LCE Lite AAR on your local machine (see [here](#2-add-lce-compatible-tensorflow-lite-aar-to-the-project) for instructions for either approach).
+This can be achieved either by using our pre-built [LCE Lite AAR](https://github.com/larq/compute-engine/releases) (under 'assets'), or you can build the LCE Lite AAR on your local machine (see [here](#2-add-lce-compatible-tensorflow-lite-aar-to-the-project) for instructions for either approach).
 
-If you'd rather build a command line binary than a full Android app, [this guide](/compute-engine/build/android/) describes how to build
-a LCE-compatible inference binary that can be executed on Android OS (e.g to [benchmark your models](/compute-engine/benchmark/)).
+If you'd rather build a command-line binary than a full Android app, [this guide](/compute-engine/build/android/) describes how to build
+an LCE-compatible inference binary that can be executed on Android OS (e.g to [benchmark your models](/compute-engine/benchmark/)).
 
 ## Create Your Own Android app using LCE and TensorFlow Lite
 
@@ -19,7 +19,9 @@ To get started with TensorFlow Lite on Android, we recommend to carefully read t
 TensorFlow Lite [Android quickstart](https://www.tensorflow.org/lite/guide/android)
 before proceeding with the next steps in this guide.
 
-### 1. Build in Android Studio
+All the required code changes below can also be found in [this patch file](android_example_with_lce.patch). Note that step 1 below still needs to be done and that step 3 also requires an `nvm install`.
+
+### 1. Get the TensorFlow Lite demo app
 
 To download and build the TensorFlow Lite Android image classification app
 in [Android Studio](https://developer.android.com/studio), follow the instructions
@@ -27,31 +29,24 @@ in [Android Studio](https://developer.android.com/studio), follow the instructio
 For an explanation of the source code,
 see [here](https://github.com/tensorflow/examples/blob/master/lite/examples/image_classification/android/EXPLORE_THE_CODE.md).
 
-### 2. Add LCE-compatible TensorFlow Lite AAR to the project ###
-To add the LCE Lite AAR to your android project, you can either use the pre-built
-[LCE Lite AAR hosted on Bintray](https://bintray.com/plumeraihq/larq-compute-engine)
+### 2. Use the 'support' API
+
+The demo TensorFlow Lite Android image classification app supports two APIs: 'support' and 'task'.
+For use with Larq, we need to select the non-default support API. The two APIs are defined under
+`flavorDimensions` in `app/build.gradle`.
+
+In Android Studio, the easiest is to go to `Build` -> `Select Build Variant` and select for the four
+options: `supportDebug`, `debug`, `debug`, and `debug`. Then make sure you do a Gradle-sync before building.
+
+### 3. Add LCE-compatible TensorFlow Lite AAR to the project ###
+To add the LCE Lite AAR to your android project, you can either use the
+pre-built [LCE Lite AAR](https://github.com/larq/compute-engine/releases) (under 'assets')
 or build the LCE Lite AAR yourself on your local machine. Both approaches are explained
 in detail in the following sections.
 
-=== "Use the LCE Lite AAR from Bintray"
-    To use LCE Lite AAR in the android app, we recommend using the
-    [LCE package hosted at Bintray](https://bintray.com/plumeraihq/larq-compute-engine).
-    Modify the `build.gradle` file in the Android project to include the
-    `lce-lite` dependency:
-
-    ```gradle
-    allprojects {
-        repositories {
-            maven {
-                url  "https://dl.bintray.com/plumeraihq/larq-compute-engine"
-            }
-        }
-    }
-
-    dependencies {
-        implementation 'org.larq:lce-lite:0.4.0'
-    }
-    ```
+=== "Use the LCE Lite AAR from the GitHub release assets"
+    To use LCE Lite AAR in the android app, we recommend downloading the
+    [LCE package released on GitHub under 'assets'](https://github.com/larq/compute-engine/releases) to your local machine. Then follow the instructions below as if you've built the AAR locally.
 
     This AAR includes binaries for `arm64-v8a`, `x86_64`, `x86` [Android ABIs](https://developer.android.com/ndk/guides/abis).
     Please note that currently hand-optimized LCE operators are available only for `arm64-v8a`.
@@ -66,7 +61,7 @@ in detail in the following sections.
     tested inside the LCE Docker container. See the LCE [build guide](/compute-engine/build/) to
     setup the Docker container.
 
-    Once the Docker container is setup, run the following command from the LCE root
+    Once the Docker container is set-up, run the following command from the LCE root
     directory inside the container:
 
     ```bash
@@ -76,67 +71,78 @@ in detail in the following sections.
     store the file in the root directory of LCE repository.
 
     Transfer the LCE Android archive file from the LCE container to the host
-    machine (where the Android Studio is setup).
-    Execute the following command to install the LCE Android Archive
-    to local [Maven](https://maven.apache.org) repository:
+    machine (where the Android Studio is set-up).
 
-    ```
-    mvn install:install-file \
-        -Dfile=lce-lite-0.4.0.aar \
-        -DgroupId=org.larq \
-        -DartifactId=lce-lite -Dversion=0.1.000 -Dpackaging=aar
-    ```
+Now execute the following command to install your LCE Android Archive `lce-lite-vX.Y.Z.aar`
+to a local [Maven](https://maven.apache.org) repository:
 
-    Modify the `build.gradle` file in the the Android project to
-    include `mavenLocal()` repository:
+```
+mvn install:install-file \
+    -Dfile=lce-lite-vX.Y.Z.aar \
+    -DgroupId=org.larq \
+    -DartifactId=lce-lite -Dversion=0.1.000 -Dpackaging=aar
+```
 
-    ```gradle
-    allprojects {
-        repositories {
-            jcenter()
-            mavenLocal()
-        }
+Modify the `build.gradle` file in the the root of the Android project to
+include `mavenLocal()` repository:
+
+```gradle
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+        mavenLocal()  # <--- new line added
     }
-    ```
+}
+```
 
-    Replace the standard TensorFlow Lite dependency with
-    local LCE Lite AAR:
+Replace the standard TensorFlow Lite dependency with
+local LCE Lite AAR in `lib_support/build.gradle` and remove
+the standard TensorFlow Lite dependency, but keep the
+`tensorflow-lite-gpu` and `tensorflow-lite-support` dependencies.
+The latter needs to be kept only partially, see the added exclude line below.
 
-    ```gradle
-    dependencies {
-        implementation 'org.larq:lce-lite:0.1.000'
+```gradle
+dependencies {
+    (...)
+
+    implementation 'org.larq:lce-lite:0.1.000'  # <--- new line added
+    // implementation 'org.tensorflow:tensorflow-lite:0.0.0-nightly-SNAPSHOT'  # <--- commented out
+    implementation 'org.tensorflow:tensorflow-lite-gpu:0.0.0-nightly-SNAPSHOT'
+
+    implementation ('org.tensorflow:tensorflow-lite-support:0.1.0') {
+        exclude module: 'tensorflow-lite'  # <--- this 'exclude' is added
     }
-    ```
+}
+```
 
-    Note that the version `0.1.000` is chosen arbitrarily and should match the version
-    passed to the `-Dversion` argument in Maven command executed previously.
+Note that the version `0.1.000` is chosen arbitrarily and should match the version
+passed to the `-Dversion` argument in the Maven command executed previously.
 
-!!! note
-    In TensorFlow Lite image classification app, you need to also remove
-    the standard TensorFlow Lite dependency by commenting out the following
-    line in `build.gradle` file:
+### 4. Disable XNNPACK ###
 
-    ```gradle
-    dependencies {
-        // Comment out the following line
-        // implementation 'org.tensorflow:tensorflow-lite:0.0.0-nightly'
-    }
-    ```
-    Note that the dependencies `tensorflow-lite-gpu` and `tensorflow-lite-support` are still required!
+With the above changes XNNPACK does not work, but we do not need this anyway with LCE.
+We can disable it by changing line 222 in `Classifier.java` (under the `lib_support` folder):
+```java
+      case CPU:
+        tfliteOptions.setUseXNNPACK(false);  // <--- was 'true' before
+        Log.d(TAG, "CPU execution");
+        break;
+```
 
-### 3. Add Larq Model to the project ###
+### 5. Add Larq Model to the project ###
 
 In this guide, we use the Larq [QuickNet](/zoo/api/sota/#quicknet)
 model for efficient and fast image classification. The FlatBuffer format of the QuickNet model
-`quicknet.tflite` can be created by using the [LCE converter](/compute-engine/api/python/) (also see our [Model Conversion and Benchmarking Guide](/compute-engine/end_to_end)) and needs to be placed in the `assets` folder of the Android project.
+`quicknet.tflite` can be created by using the [LCE converter](/compute-engine/api/python/) (also see our [Model Conversion and Benchmarking Guide](/compute-engine/end_to_end)) and needs to be placed in the `assets` folder of the Android project, within `models/src/main/`.
 You also need to use the `labels_without_background.txt` as its corresponding labels file.
 The labels file is already available in the `asset` folder of
 the TensorFlow Lite image classification Android app.
 
 The TensorFlow Lite classifier in the image classifaction app works with the
 float MobileNet model. To replace the MobileNet with QuickNet, you need to modify
-`getModelPath()` and `getLabelPath()` methods in `ClassifierFloatMobileNet.java`
-file.
+`getModelPath()` and `getLabelPath()` methods in the `ClassifierFloatMobileNet.java`
+file (under the `lib_support` folder):
 
 ```java
 @Override
@@ -159,7 +165,7 @@ private static final float[] IMAGE_STD = {0.229f * 255, 0.224f * 255, 0.225f * 2
 ```
 
 Now you will be able to build the App in Android Studio and run it on your Android phone.
-Choose the `Float` model in the app drop-down list to use QuickNet for inference.
+Choose the `Float_Mobilenet` model in the app drop-down list to use QuickNet for inference with the `CPU`.
 The following screenshot shows an example of image classification using LCE Lite AAR as
 the inference engine.
 


### PR DESCRIPTION
This updates the instructions for the TFLite android example app in various ways:

1. Clarifies a few minor things in the text.
2. Adds a patch file with all code-changes required in one go.
3. Applies some of the suggestions from [this comment](https://github.com/larq/compute-engine/issues/602#issuecomment-775962340) to make the dependencies-change work again.
4. Disables XNNPACK to resolve the issues [encountered here](https://github.com/larq/compute-engine/issues/602).
5. Adds instructions on how to select the right API as also [described here](https://github.com/larq/compute-engine/issues/636).
6. Replaces Bintray release support with manual downloading from the GitHub release page.

This was all tested together and I managed to classify a banana with my phone:
![banana_classification](https://user-images.githubusercontent.com/1162108/124484947-54197500-ddac-11eb-82b8-3be3768e4f3f.png)

Review tip: enable `Hide whitespace changes` to get a nicer diff.